### PR TITLE
stkSWIV: Complete ERC-4626 Conversion

### DIFF
--- a/stkSWIV.sol
+++ b/stkSWIV.sol
@@ -6,7 +6,7 @@ import './Utils/SafeTransferLib.sol';
 
 contract stkSWIV is ERC20 {
 
-    ERC20 immutable SWIV;
+    ERC20 public immutable SWIV;
 
     uint256 public totalDeposited;
 
@@ -14,13 +14,63 @@ contract stkSWIV is ERC20 {
         SWIV = s;
     }
 
+    ////////////////// READ METHODS //////////////////
     function exchangeRateCurrent() public view returns (uint256) {
         return ((SWIV.balanceOf(address(this))*1e26)/totalDeposited);
     }
 
-    function mint(uint256 shares, address receiver) public returns (uint256) {
+    function totalAssets() public view returns (uint256 totalManagedAssets) {
+        return (SWIV.balanceOf(address(this)));
+    }
 
-        uint256 assets = (shares * exchangeRateCurrent())/1e26;
+    function asset() public view returns (ERC20 assetTokenAddress) {
+        return(SWIV);
+    }
+
+    function convertToShares(uint256 assets) public view returns (uint256 shares) {
+        return((assets * 1e26)/exchangeRateCurrent());
+    }
+
+    function convertToAssets(uint256 shares) public view returns (uint256 assets) {
+        return((shares * exchangeRateCurrent())/1e26);
+    }
+
+    function maxDeposit(address receiver) public pure returns (uint256 maxAssets) {
+        return(2 ** 256 - 1);
+    }
+
+    function maxMint(address receiver) public pure returns (uint256 maxShares) {
+        return(2 ** 256 - 1);
+    }   
+
+    function maxRedeem(address owner) public view returns (uint256 maxShares) {
+        return(balanceOf[owner]);
+    }      
+
+    function maxWithdraw(address owner) public view returns (uint256 maxAssets) {
+        return(convertToAssets(balanceOf[owner]));
+    }
+
+    function previewMint(uint256 shares) public view returns (uint256 assets) {
+        return(convertToAssets(shares));
+    }
+
+    function previewDeposit(uint256 assets) public view returns (uint256 shares) {
+        return(convertToShares(assets));
+    }
+
+    function previewRedeem(uint256 shares) public view returns (uint256 assets) {
+        return(convertToAssets(shares));
+    }
+
+    function previewWithdraw(uint256 assets) public view returns (uint256 shares) {
+        return(convertToShares(assets));
+    }
+
+    ////////////////// WRITE METHODS //////////////////
+    function mint(uint256 shares, address receiver) public returns (uint256 assets) {
+
+        assets = convertToAssets(shares);
 
         totalDeposited += assets;
 
@@ -31,9 +81,9 @@ contract stkSWIV is ERC20 {
         return (assets);
     }
 
-    function deposit(uint256 assets, address receiver) public returns (uint256) {
+    function deposit(uint256 assets, address receiver) public returns (uint256 shares) {
 
-        uint256 shares = ((assets * 1e26)/exchangeRateCurrent());
+        shares = convertToAssets(assets);
         
         totalDeposited += assets;
 
@@ -44,9 +94,9 @@ contract stkSWIV is ERC20 {
         return (shares);
     }
 
-    function withdraw(uint256 assets, address receiver) public returns (uint256) {
+    function withdraw(uint256 assets, address receiver) public returns (uint256 shares) {
 
-        uint256 shares = ((assets * 1e26)/exchangeRateCurrent());
+        shares = convertToAssets(assets);
 
         _burn(msg.sender, shares);
 
@@ -55,9 +105,9 @@ contract stkSWIV is ERC20 {
         return (shares);
     }
 
-    function redeem(uint256 shares, address receiver) public returns (uint256) {
+    function redeem(uint256 shares, address receiver) public returns (uint256 assets) {
 
-        uint256 assets = (shares * exchangeRateCurrent())/1e26;
+        assets = convertToAssets(shares);
 
         _burn(msg.sender, shares);
 

--- a/stkSWIV.sol
+++ b/stkSWIV.sol
@@ -18,47 +18,51 @@ contract stkSWIV is ERC20 {
         return ((SWIV.balanceOf(address(this))*1e26)/totalDeposited);
     }
 
-    function mint(uint256 amount) public returns (uint256) {
+    function mint(uint256 shares, address receiver) public returns (uint256) {
 
-        SafeTransferLib.transferFrom(SWIV, msg.sender, address(this), amount);
+        uint256 assets = (shares * exchangeRateCurrent())/1e26;
 
-        uint256 returned = ((amount * 1e26)/exchangeRateCurrent());
+        totalDeposited += assets;
 
-        _mint(msg.sender, returned);
+        SafeTransferLib.transferFrom(SWIV, msg.sender, address(this), assets);        
 
-        return (returned);
+        _mint(receiver, shares);
+
+        return (assets);
     }
 
-    function deposit(uint256 amount) public returns (uint256) {
+    function deposit(uint256 assets, address receiver) public returns (uint256) {
 
-        uint256 sent = (amount * exchangeRateCurrent())/1e26;
+        uint256 shares = ((assets * 1e26)/exchangeRateCurrent());
+        
+        totalDeposited += assets;
 
-        SafeTransferLib.transferFrom(SWIV, msg.sender, address(this), sent);        
+        SafeTransferLib.transferFrom(SWIV, msg.sender, address(this), assets);
 
-        _mint(msg.sender, amount);
+        _mint(receiver, shares);
 
-        return (amount);
+        return (shares);
     }
 
-    function redeemUnderlying(uint256 amount) public returns (uint256) {
+    function withdraw(uint256 assets, address receiver) public returns (uint256) {
 
-        uint256 sent = ((amount * 1e26)/exchangeRateCurrent());
+        uint256 shares = ((assets * 1e26)/exchangeRateCurrent());
 
-        _burn(msg.sender, sent);
+        _burn(msg.sender, shares);
 
-        SafeTransferLib.transfer(SWIV, msg.sender, amount);
+        SafeTransferLib.transfer(SWIV, receiver, assets);
 
-        return (amount);
+        return (shares);
     }
 
-    function redeemShares(uint256 amount) public returns (uint256) {
+    function redeem(uint256 shares, address receiver) public returns (uint256) {
 
-        uint256 returned = (amount * exchangeRateCurrent())/1e26;
+        uint256 assets = (shares * exchangeRateCurrent())/1e26;
 
-        _burn(msg.sender, amount);
+        _burn(msg.sender, shares);
 
-        SafeTransferLib.transfer(SWIV, msg.sender, returned);
+        SafeTransferLib.transfer(SWIV, receiver, assets);
 
-        return (amount);
+        return (assets);
     }
 }


### PR DESCRIPTION
Completed conversion for stkSWIV token to 4626 integration.

There are a number of pretty redundant read methods, but its all just to stay compliant to the 4626 spec.