### PR TITLE
Everything Except Balancer

### DIFF
--- a/Interfaces/IAsset.sol
+++ b/Interfaces/IAsset.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity >=0.7.0 <0.9.0;
+
+/**
+ * @dev This is an empty interface used to represent either ERC20-conforming token contracts or ETH (using the zero
+ * address sentinel value). We're just relying on the fact that `interface` can be used to declare new address-like
+ * types.
+ *
+ * This concept is unrelated to a Pool's Asset Managers.
+ */
+interface IAsset {
+    // solhint-disable-previous-line no-empty-blocks
+}

--- a/Interfaces/IAuthentication.sol
+++ b/Interfaces/IAuthentication.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity >=0.7.0 <0.9.0;
+
+interface IAuthentication {
+    /**
+     * @dev Returns the action identifier associated with the external function described by `selector`.
+     */
+    function getActionId(bytes4 selector) external view returns (bytes32);
+}

--- a/Interfaces/IAuthorizer.sol
+++ b/Interfaces/IAuthorizer.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity >=0.7.0 <0.9.0;
+
+interface IAuthorizer {
+    /**
+     * @dev Returns true if `account` can perform the action described by `actionId` in the contract `where`.
+     */
+    function canPerform(
+        bytes32 actionId,
+        address account,
+        address where
+    ) external view returns (bool);
+}

--- a/Interfaces/IERC20.sol
+++ b/Interfaces/IERC20.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.7.0 <0.9.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * IMPORTANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}

--- a/Interfaces/IFlashLoanRecipient.sol
+++ b/Interfaces/IFlashLoanRecipient.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity >=0.7.0 <0.9.0;
+
+// Inspired by Aave Protocol's IFlashLoanReceiver.
+
+import "../solidity-utils/openzeppelin/IERC20.sol";
+
+interface IFlashLoanRecipient {
+    /**
+     * @dev When `flashLoan` is called on the Vault, it invokes the `receiveFlashLoan` hook on the recipient.
+     *
+     * At the time of the call, the Vault will have transferred `amounts` for `tokens` to the recipient. Before this
+     * call returns, the recipient must have transferred `amounts` plus `feeAmounts` for each token back to the
+     * Vault, or else the entire flash loan will revert.
+     *
+     * `userData` is the same value passed in the `IVault.flashLoan` call.
+     */
+    function receiveFlashLoan(
+        IERC20[] memory tokens,
+        uint256[] memory amounts,
+        uint256[] memory feeAmounts,
+        bytes memory userData
+    ) external;
+}

--- a/Interfaces/IPoolSwapStructs.sol
+++ b/Interfaces/IPoolSwapStructs.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity >=0.7.0 <0.9.0;
+pragma experimental ABIEncoderV2;
+
+import "../solidity-utils/openzeppelin/IERC20.sol";
+
+import "./IVault.sol";
+
+interface IPoolSwapStructs {
+    // This is not really an interface - it just defines common structs used by other interfaces: IGeneralPool and
+    // IMinimalSwapInfoPool.
+    //
+    // This data structure represents a request for a token swap, where `kind` indicates the swap type ('given in' or
+    // 'given out') which indicates whether or not the amount sent by the pool is known.
+    //
+    // The pool receives `tokenIn` and sends `tokenOut`. `amount` is the number of `tokenIn` tokens the pool will take
+    // in, or the number of `tokenOut` tokens the Pool will send out, depending on the given swap `kind`.
+    //
+    // All other fields are not strictly necessary for most swaps, but are provided to support advanced scenarios in
+    // some Pools.
+    //
+    // `poolId` is the ID of the Pool involved in the swap - this is useful for Pool contracts that implement more than
+    // one Pool.
+    //
+    // The meaning of `lastChangeBlock` depends on the Pool specialization:
+    //  - Two Token or Minimal Swap Info: the last block in which either `tokenIn` or `tokenOut` changed its total
+    //    balance.
+    //  - General: the last block in which *any* of the Pool's registered tokens changed its total balance.
+    //
+    // `from` is the origin address for the funds the Pool receives, and `to` is the destination address
+    // where the Pool sends the outgoing tokens.
+    //
+    // `userData` is extra data provided by the caller - typically a signature from a trusted party.
+    struct SwapRequest {
+        IVault.SwapKind kind;
+        IERC20 tokenIn;
+        IERC20 tokenOut;
+        uint256 amount;
+        // Misc data
+        bytes32 poolId;
+        uint256 lastChangeBlock;
+        address from;
+        address to;
+        bytes userData;
+    }
+}

--- a/Interfaces/ISignaturesValidator.sol
+++ b/Interfaces/ISignaturesValidator.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity >=0.7.0 <0.9.0;
+
+/**
+ * @dev Interface for the SignatureValidator helper, used to support meta-transactions.
+ */
+interface ISignaturesValidator {
+    /**
+     * @dev Returns the EIP712 domain separator.
+     */
+    function getDomainSeparator() external view returns (bytes32);
+
+    /**
+     * @dev Returns the next nonce used by an address to sign messages.
+     */
+    function getNextNonce(address user) external view returns (uint256);
+}

--- a/Interfaces/IVault.sol
+++ b/Interfaces/IVault.sol
@@ -1,0 +1,772 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma experimental ABIEncoderV2;
+
+import "./IERC20.sol";
+import "./IAuthentication.sol";
+import "./ISignaturesValidator.sol";
+import "./ITemporarilyPausable.sol"; 
+import "./IWETH.sol";
+
+import "./IAsset.sol";
+import "./IAuthorizer.sol"; 
+import "./IFlashLoanRecipient.sol";
+import "./IProtocolFeesCollector.sol";
+
+pragma solidity >=0.7.0 <0.9.0;
+
+/**
+ * @dev Full external interface for the Vault core contract - no external or public methods exist in the contract that
+ * don't override one of these declarations.
+ */
+interface IVault is ISignaturesValidator, ITemporarilyPausable, IAuthentication {
+    // Generalities about the Vault:
+    //
+    // - Whenever documentation refers to 'tokens', it strictly refers to ERC20-compliant token contracts. Tokens are
+    // transferred out of the Vault by calling the `IERC20.transfer` function, and transferred in by calling
+    // `IERC20.transferFrom`. In these cases, the sender must have previously allowed the Vault to use their tokens by
+    // calling `IERC20.approve`. The only deviation from the ERC20 standard that is supported is functions not returning
+    // a boolean value: in these scenarios, a non-reverting call is assumed to be successful.
+    //
+    // - All non-view functions in the Vault are non-reentrant: calling them while another one is mid-execution (e.g.
+    // while execution control is transferred to a token contract during a swap) will result in a revert. View
+    // functions can be called in a re-reentrant way, but doing so might cause them to return inconsistent results.
+    // Contracts calling view functions in the Vault must make sure the Vault has not already been entered.
+    //
+    // - View functions revert if referring to either unregistered Pools, or unregistered tokens for registered Pools.
+
+    // Authorizer
+    //
+    // Some system actions are permissioned, like setting and collecting protocol fees. This permissioning system exists
+    // outside of the Vault in the Authorizer contract: the Vault simply calls the Authorizer to check if the caller
+    // can perform a given action.
+
+    /**
+     * @dev Returns the Vault's Authorizer.
+     */
+    function getAuthorizer() external view returns (IAuthorizer);
+
+    /**
+     * @dev Sets a new Authorizer for the Vault. The caller must be allowed by the current Authorizer to do this.
+     *
+     * Emits an `AuthorizerChanged` event.
+     */
+    function setAuthorizer(IAuthorizer newAuthorizer) external;
+
+    /**
+     * @dev Emitted when a new authorizer is set by `setAuthorizer`.
+     */
+    event AuthorizerChanged(IAuthorizer indexed newAuthorizer);
+
+    // Relayers
+    //
+    // Additionally, it is possible for an account to perform certain actions on behalf of another one, using their
+    // Vault ERC20 allowance and Internal Balance. These accounts are said to be 'relayers' for these Vault functions,
+    // and are expected to be smart contracts with sound authentication mechanisms. For an account to be able to wield
+    // this power, two things must occur:
+    //  - The Authorizer must grant the account the permission to be a relayer for the relevant Vault function. This
+    //    means that Balancer governance must approve each individual contract to act as a relayer for the intended
+    //    functions.
+    //  - Each user must approve the relayer to act on their behalf.
+    // This double protection means users cannot be tricked into approving malicious relayers (because they will not
+    // have been allowed by the Authorizer via governance), nor can malicious relayers approved by a compromised
+    // Authorizer or governance drain user funds, since they would also need to be approved by each individual user.
+
+    /**
+     * @dev Returns true if `user` has approved `relayer` to act as a relayer for them.
+     */
+    function hasApprovedRelayer(address user, address relayer) external view returns (bool);
+
+    /**
+     * @dev Allows `relayer` to act as a relayer for `sender` if `approved` is true, and disallows it otherwise.
+     *
+     * Emits a `RelayerApprovalChanged` event.
+     */
+    function setRelayerApproval(
+        address sender,
+        address relayer,
+        bool approved
+    ) external;
+
+    /**
+     * @dev Emitted every time a relayer is approved or disapproved by `setRelayerApproval`.
+     */
+    event RelayerApprovalChanged(address indexed relayer, address indexed sender, bool approved);
+
+    // Internal Balance
+    //
+    // Users can deposit tokens into the Vault, where they are allocated to their Internal Balance, and later
+    // transferred or withdrawn. It can also be used as a source of tokens when joining Pools, as a destination
+    // when exiting them, and as either when performing swaps. This usage of Internal Balance results in greatly reduced
+    // gas costs when compared to relying on plain ERC20 transfers, leading to large savings for frequent users.
+    //
+    // Internal Balance management features batching, which means a single contract call can be used to perform multiple
+    // operations of different kinds, with different senders and recipients, at once.
+
+    /**
+     * @dev Returns `user`'s Internal Balance for a set of tokens.
+     */
+    function getInternalBalance(address user, IERC20[] memory tokens) external view returns (uint256[] memory);
+
+    /**
+     * @dev Performs a set of user balance operations, which involve Internal Balance (deposit, withdraw or transfer)
+     * and plain ERC20 transfers using the Vault's allowance. This last feature is particularly useful for relayers, as
+     * it lets integrators reuse a user's Vault allowance.
+     *
+     * For each operation, if the caller is not `sender`, it must be an authorized relayer for them.
+     */
+    function manageUserBalance(UserBalanceOp[] memory ops) external payable;
+
+    /**
+     * @dev Data for `manageUserBalance` operations, which include the possibility for ETH to be sent and received
+     without manual WETH wrapping or unwrapping.
+     */
+    struct UserBalanceOp {
+        UserBalanceOpKind kind;
+        IAsset asset;
+        uint256 amount;
+        address sender;
+        address payable recipient;
+    }
+
+    // There are four possible operations in `manageUserBalance`:
+    //
+    // - DEPOSIT_INTERNAL
+    // Increases the Internal Balance of the `recipient` account by transferring tokens from the corresponding
+    // `sender`. The sender must have allowed the Vault to use their tokens via `IERC20.approve()`.
+    //
+    // ETH can be used by passing the ETH sentinel value as the asset and forwarding ETH in the call: it will be wrapped
+    // and deposited as WETH. Any ETH amount remaining will be sent back to the caller (not the sender, which is
+    // relevant for relayers).
+    //
+    // Emits an `InternalBalanceChanged` event.
+    //
+    //
+    // - WITHDRAW_INTERNAL
+    // Decreases the Internal Balance of the `sender` account by transferring tokens to the `recipient`.
+    //
+    // ETH can be used by passing the ETH sentinel value as the asset. This will deduct WETH instead, unwrap it and send
+    // it to the recipient as ETH.
+    //
+    // Emits an `InternalBalanceChanged` event.
+    //
+    //
+    // - TRANSFER_INTERNAL
+    // Transfers tokens from the Internal Balance of the `sender` account to the Internal Balance of `recipient`.
+    //
+    // Reverts if the ETH sentinel value is passed.
+    //
+    // Emits an `InternalBalanceChanged` event.
+    //
+    //
+    // - TRANSFER_EXTERNAL
+    // Transfers tokens from `sender` to `recipient`, using the Vault's ERC20 allowance. This is typically used by
+    // relayers, as it lets them reuse a user's Vault allowance.
+    //
+    // Reverts if the ETH sentinel value is passed.
+    //
+    // Emits an `ExternalBalanceTransfer` event.
+
+    enum UserBalanceOpKind { DEPOSIT_INTERNAL, WITHDRAW_INTERNAL, TRANSFER_INTERNAL, TRANSFER_EXTERNAL }
+
+    /**
+     * @dev Emitted when a user's Internal Balance changes, either from calls to `manageUserBalance`, or through
+     * interacting with Pools using Internal Balance.
+     *
+     * Because Internal Balance works exclusively with ERC20 tokens, ETH deposits and withdrawals will use the WETH
+     * address.
+     */
+    event InternalBalanceChanged(address indexed user, IERC20 indexed token, int256 delta);
+
+    /**
+     * @dev Emitted when a user's Vault ERC20 allowance is used by the Vault to transfer tokens to an external account.
+     */
+    event ExternalBalanceTransfer(IERC20 indexed token, address indexed sender, address recipient, uint256 amount);
+
+    // Pools
+    //
+    // There are three specialization settings for Pools, which allow for cheaper swaps at the cost of reduced
+    // functionality:
+    //
+    //  - General: no specialization, suited for all Pools. IGeneralPool is used for swap request callbacks, passing the
+    // balance of all tokens in the Pool. These Pools have the largest swap costs (because of the extra storage reads),
+    // which increase with the number of registered tokens.
+    //
+    //  - Minimal Swap Info: IMinimalSwapInfoPool is used instead of IGeneralPool, which saves gas by only passing the
+    // balance of the two tokens involved in the swap. This is suitable for some pricing algorithms, like the weighted
+    // constant product one popularized by Balancer V1. Swap costs are smaller compared to general Pools, and are
+    // independent of the number of registered tokens.
+    //
+    //  - Two Token: only allows two tokens to be registered. This achieves the lowest possible swap gas cost. Like
+    // minimal swap info Pools, these are called via IMinimalSwapInfoPool.
+
+    enum PoolSpecialization { GENERAL, MINIMAL_SWAP_INFO, TWO_TOKEN }
+
+    /**
+     * @dev Registers the caller account as a Pool with a given specialization setting. Returns the Pool's ID, which
+     * is used in all Pool-related functions. Pools cannot be deregistered, nor can the Pool's specialization be
+     * changed.
+     *
+     * The caller is expected to be a smart contract that implements either `IGeneralPool` or `IMinimalSwapInfoPool`,
+     * depending on the chosen specialization setting. This contract is known as the Pool's contract.
+     *
+     * Note that the same contract may register itself as multiple Pools with unique Pool IDs, or in other words,
+     * multiple Pools may share the same contract.
+     *
+     * Emits a `PoolRegistered` event.
+     */
+    function registerPool(PoolSpecialization specialization) external returns (bytes32);
+
+    /**
+     * @dev Emitted when a Pool is registered by calling `registerPool`.
+     */
+    event PoolRegistered(bytes32 indexed poolId, address indexed poolAddress, PoolSpecialization specialization);
+
+    /**
+     * @dev Returns a Pool's contract address and specialization setting.
+     */
+    function getPool(bytes32 poolId) external view returns (address, PoolSpecialization);
+
+    /**
+     * @dev Registers `tokens` for the `poolId` Pool. Must be called by the Pool's contract.
+     *
+     * Pools can only interact with tokens they have registered. Users join a Pool by transferring registered tokens,
+     * exit by receiving registered tokens, and can only swap registered tokens.
+     *
+     * Each token can only be registered once. For Pools with the Two Token specialization, `tokens` must have a length
+     * of two, that is, both tokens must be registered in the same `registerTokens` call, and they must be sorted in
+     * ascending order.
+     *
+     * The `tokens` and `assetManagers` arrays must have the same length, and each entry in these indicates the Asset
+     * Manager for the corresponding token. Asset Managers can manage a Pool's tokens via `managePoolBalance`,
+     * depositing and withdrawing them directly, and can even set their balance to arbitrary amounts. They are therefore
+     * expected to be highly secured smart contracts with sound design principles, and the decision to register an
+     * Asset Manager should not be made lightly.
+     *
+     * Pools can choose not to assign an Asset Manager to a given token by passing in the zero address. Once an Asset
+     * Manager is set, it cannot be changed except by deregistering the associated token and registering again with a
+     * different Asset Manager.
+     *
+     * Emits a `TokensRegistered` event.
+     */
+    function registerTokens(
+        bytes32 poolId,
+        IERC20[] memory tokens,
+        address[] memory assetManagers
+    ) external;
+
+    /**
+     * @dev Emitted when a Pool registers tokens by calling `registerTokens`.
+     */
+    event TokensRegistered(bytes32 indexed poolId, IERC20[] tokens, address[] assetManagers);
+
+    /**
+     * @dev Deregisters `tokens` for the `poolId` Pool. Must be called by the Pool's contract.
+     *
+     * Only registered tokens (via `registerTokens`) can be deregistered. Additionally, they must have zero total
+     * balance. For Pools with the Two Token specialization, `tokens` must have a length of two, that is, both tokens
+     * must be deregistered in the same `deregisterTokens` call.
+     *
+     * A deregistered token can be re-registered later on, possibly with a different Asset Manager.
+     *
+     * Emits a `TokensDeregistered` event.
+     */
+    function deregisterTokens(bytes32 poolId, IERC20[] memory tokens) external;
+
+    /**
+     * @dev Emitted when a Pool deregisters tokens by calling `deregisterTokens`.
+     */
+    event TokensDeregistered(bytes32 indexed poolId, IERC20[] tokens);
+
+    /**
+     * @dev Returns detailed information for a Pool's registered token.
+     *
+     * `cash` is the number of tokens the Vault currently holds for the Pool. `managed` is the number of tokens
+     * withdrawn and held outside the Vault by the Pool's token Asset Manager. The Pool's total balance for `token`
+     * equals the sum of `cash` and `managed`.
+     *
+     * Internally, `cash` and `managed` are stored using 112 bits. No action can ever cause a Pool's token `cash`,
+     * `managed` or `total` balance to be greater than 2^112 - 1.
+     *
+     * `lastChangeBlock` is the number of the block in which `token`'s total balance was last modified (via either a
+     * join, exit, swap, or Asset Manager update). This value is useful to avoid so-called 'sandwich attacks', for
+     * example when developing price oracles. A change of zero (e.g. caused by a swap with amount zero) is considered a
+     * change for this purpose, and will update `lastChangeBlock`.
+     *
+     * `assetManager` is the Pool's token Asset Manager.
+     */
+    function getPoolTokenInfo(bytes32 poolId, IERC20 token)
+        external
+        view
+        returns (
+            uint256 cash,
+            uint256 managed,
+            uint256 lastChangeBlock,
+            address assetManager
+        );
+
+    /**
+     * @dev Returns a Pool's registered tokens, the total balance for each, and the latest block when *any* of
+     * the tokens' `balances` changed.
+     *
+     * The order of the `tokens` array is the same order that will be used in `joinPool`, `exitPool`, as well as in all
+     * Pool hooks (where applicable). Calls to `registerTokens` and `deregisterTokens` may change this order.
+     *
+     * If a Pool only registers tokens once, and these are sorted in ascending order, they will be stored in the same
+     * order as passed to `registerTokens`.
+     *
+     * Total balances include both tokens held by the Vault and those withdrawn by the Pool's Asset Managers. These are
+     * the amounts used by joins, exits and swaps. For a detailed breakdown of token balances, use `getPoolTokenInfo`
+     * instead.
+     */
+    function getPoolTokens(bytes32 poolId)
+        external
+        view
+        returns (
+            IERC20[] memory tokens,
+            uint256[] memory balances,
+            uint256 lastChangeBlock
+        );
+
+    /**
+     * @dev Called by users to join a Pool, which transfers tokens from `sender` into the Pool's balance. This will
+     * trigger custom Pool behavior, which will typically grant something in return to `recipient` - often tokenized
+     * Pool shares.
+     *
+     * If the caller is not `sender`, it must be an authorized relayer for them.
+     *
+     * The `assets` and `maxAmountsIn` arrays must have the same length, and each entry indicates the maximum amount
+     * to send for each asset. The amounts to send are decided by the Pool and not the Vault: it just enforces
+     * these maximums.
+     *
+     * If joining a Pool that holds WETH, it is possible to send ETH directly: the Vault will do the wrapping. To enable
+     * this mechanism, the IAsset sentinel value (the zero address) must be passed in the `assets` array instead of the
+     * WETH address. Note that it is not possible to combine ETH and WETH in the same join. Any excess ETH will be sent
+     * back to the caller (not the sender, which is important for relayers).
+     *
+     * `assets` must have the same length and order as the array returned by `getPoolTokens`. This prevents issues when
+     * interacting with Pools that register and deregister tokens frequently. If sending ETH however, the array must be
+     * sorted *before* replacing the WETH address with the ETH sentinel value (the zero address), which means the final
+     * `assets` array might not be sorted. Pools with no registered tokens cannot be joined.
+     *
+     * If `fromInternalBalance` is true, the caller's Internal Balance will be preferred: ERC20 transfers will only
+     * be made for the difference between the requested amount and Internal Balance (if any). Note that ETH cannot be
+     * withdrawn from Internal Balance: attempting to do so will trigger a revert.
+     *
+     * This causes the Vault to call the `IBasePool.onJoinPool` hook on the Pool's contract, where Pools implement
+     * their own custom logic. This typically requires additional information from the user (such as the expected number
+     * of Pool shares). This can be encoded in the `userData` argument, which is ignored by the Vault and passed
+     * directly to the Pool's contract, as is `recipient`.
+     *
+     * Emits a `PoolBalanceChanged` event.
+     */
+    function joinPool(
+        bytes32 poolId,
+        address sender,
+        address recipient,
+        JoinPoolRequest memory request
+    ) external payable;
+
+    struct JoinPoolRequest {
+        IAsset[] assets;
+        uint256[] maxAmountsIn;
+        bytes userData;
+        bool fromInternalBalance;
+    }
+
+    /**
+     * @dev Called by users to exit a Pool, which transfers tokens from the Pool's balance to `recipient`. This will
+     * trigger custom Pool behavior, which will typically ask for something in return from `sender` - often tokenized
+     * Pool shares. The amount of tokens that can be withdrawn is limited by the Pool's `cash` balance (see
+     * `getPoolTokenInfo`).
+     *
+     * If the caller is not `sender`, it must be an authorized relayer for them.
+     *
+     * The `tokens` and `minAmountsOut` arrays must have the same length, and each entry in these indicates the minimum
+     * token amount to receive for each token contract. The amounts to send are decided by the Pool and not the Vault:
+     * it just enforces these minimums.
+     *
+     * If exiting a Pool that holds WETH, it is possible to receive ETH directly: the Vault will do the unwrapping. To
+     * enable this mechanism, the IAsset sentinel value (the zero address) must be passed in the `assets` array instead
+     * of the WETH address. Note that it is not possible to combine ETH and WETH in the same exit.
+     *
+     * `assets` must have the same length and order as the array returned by `getPoolTokens`. This prevents issues when
+     * interacting with Pools that register and deregister tokens frequently. If receiving ETH however, the array must
+     * be sorted *before* replacing the WETH address with the ETH sentinel value (the zero address), which means the
+     * final `assets` array might not be sorted. Pools with no registered tokens cannot be exited.
+     *
+     * If `toInternalBalance` is true, the tokens will be deposited to `recipient`'s Internal Balance. Otherwise,
+     * an ERC20 transfer will be performed. Note that ETH cannot be deposited to Internal Balance: attempting to
+     * do so will trigger a revert.
+     *
+     * `minAmountsOut` is the minimum amount of tokens the user expects to get out of the Pool, for each token in the
+     * `tokens` array. This array must match the Pool's registered tokens.
+     *
+     * This causes the Vault to call the `IBasePool.onExitPool` hook on the Pool's contract, where Pools implement
+     * their own custom logic. This typically requires additional information from the user (such as the expected number
+     * of Pool shares to return). This can be encoded in the `userData` argument, which is ignored by the Vault and
+     * passed directly to the Pool's contract.
+     *
+     * Emits a `PoolBalanceChanged` event.
+     */
+    function exitPool(
+        bytes32 poolId,
+        address sender,
+        address payable recipient,
+        ExitPoolRequest memory request
+    ) external;
+
+    struct ExitPoolRequest {
+        IAsset[] assets;
+        uint256[] minAmountsOut;
+        bytes userData;
+        bool toInternalBalance;
+    }
+
+    /**
+     * @dev Emitted when a user joins or exits a Pool by calling `joinPool` or `exitPool`, respectively.
+     */
+    event PoolBalanceChanged(
+        bytes32 indexed poolId,
+        address indexed liquidityProvider,
+        IERC20[] tokens,
+        int256[] deltas,
+        uint256[] protocolFeeAmounts
+    );
+
+    enum PoolBalanceChangeKind { JOIN, EXIT }
+
+    // Swaps
+    //
+    // Users can swap tokens with Pools by calling the `swap` and `batchSwap` functions. To do this,
+    // they need not trust Pool contracts in any way: all security checks are made by the Vault. They must however be
+    // aware of the Pools' pricing algorithms in order to estimate the prices Pools will quote.
+    //
+    // The `swap` function executes a single swap, while `batchSwap` can perform multiple swaps in sequence.
+    // In each individual swap, tokens of one kind are sent from the sender to the Pool (this is the 'token in'),
+    // and tokens of another kind are sent from the Pool to the recipient in exchange (this is the 'token out').
+    // More complex swaps, such as one token in to multiple tokens out can be achieved by batching together
+    // individual swaps.
+    //
+    // There are two swap kinds:
+    //  - 'given in' swaps, where the amount of tokens in (sent to the Pool) is known, and the Pool determines (via the
+    // `onSwap` hook) the amount of tokens out (to send to the recipient).
+    //  - 'given out' swaps, where the amount of tokens out (received from the Pool) is known, and the Pool determines
+    // (via the `onSwap` hook) the amount of tokens in (to receive from the sender).
+    //
+    // Additionally, it is possible to chain swaps using a placeholder input amount, which the Vault replaces with
+    // the calculated output of the previous swap. If the previous swap was 'given in', this will be the calculated
+    // tokenOut amount. If the previous swap was 'given out', it will use the calculated tokenIn amount. These extended
+    // swaps are known as 'multihop' swaps, since they 'hop' through a number of intermediate tokens before arriving at
+    // the final intended token.
+    //
+    // In all cases, tokens are only transferred in and out of the Vault (or withdrawn from and deposited into Internal
+    // Balance) after all individual swaps have been completed, and the net token balance change computed. This makes
+    // certain swap patterns, such as multihops, or swaps that interact with the same token pair in multiple Pools, cost
+    // much less gas than they would otherwise.
+    //
+    // It also means that under certain conditions it is possible to perform arbitrage by swapping with multiple
+    // Pools in a way that results in net token movement out of the Vault (profit), with no tokens being sent in (only
+    // updating the Pool's internal accounting).
+    //
+    // To protect users from front-running or the market changing rapidly, they supply a list of 'limits' for each token
+    // involved in the swap, where either the maximum number of tokens to send (by passing a positive value) or the
+    // minimum amount of tokens to receive (by passing a negative value) is specified.
+    //
+    // Additionally, a 'deadline' timestamp can also be provided, forcing the swap to fail if it occurs after
+    // this point in time (e.g. if the transaction failed to be included in a block promptly).
+    //
+    // If interacting with Pools that hold WETH, it is possible to both send and receive ETH directly: the Vault will do
+    // the wrapping and unwrapping. To enable this mechanism, the IAsset sentinel value (the zero address) must be
+    // passed in the `assets` array instead of the WETH address. Note that it is possible to combine ETH and WETH in the
+    // same swap. Any excess ETH will be sent back to the caller (not the sender, which is relevant for relayers).
+    //
+    // Finally, Internal Balance can be used when either sending or receiving tokens.
+
+    enum SwapKind { GIVEN_IN, GIVEN_OUT }
+
+    /**
+     * @dev Performs a swap with a single Pool.
+     *
+     * If the swap is 'given in' (the number of tokens to send to the Pool is known), it returns the amount of tokens
+     * taken from the Pool, which must be greater than or equal to `limit`.
+     *
+     * If the swap is 'given out' (the number of tokens to take from the Pool is known), it returns the amount of tokens
+     * sent to the Pool, which must be less than or equal to `limit`.
+     *
+     * Internal Balance usage and the recipient are determined by the `funds` struct.
+     *
+     * Emits a `Swap` event.
+     */
+    function swap(
+        SingleSwap memory singleSwap,
+        FundManagement memory funds,
+        uint256 limit,
+        uint256 deadline
+    ) external payable returns (uint256);
+
+    /**
+     * @dev Data for a single swap executed by `swap`. `amount` is either `amountIn` or `amountOut` depending on
+     * the `kind` value.
+     *
+     * `assetIn` and `assetOut` are either token addresses, or the IAsset sentinel value for ETH (the zero address).
+     * Note that Pools never interact with ETH directly: it will be wrapped to or unwrapped from WETH by the Vault.
+     *
+     * The `userData` field is ignored by the Vault, but forwarded to the Pool in the `onSwap` hook, and may be
+     * used to extend swap behavior.
+     */
+    struct SingleSwap {
+        bytes32 poolId;
+        SwapKind kind;
+        IAsset assetIn;
+        IAsset assetOut;
+        uint256 amount;
+        bytes userData;
+    }
+
+    /**
+     * @dev Performs a series of swaps with one or multiple Pools. In each individual swap, the caller determines either
+     * the amount of tokens sent to or received from the Pool, depending on the `kind` value.
+     *
+     * Returns an array with the net Vault asset balance deltas. Positive amounts represent tokens (or ETH) sent to the
+     * Vault, and negative amounts represent tokens (or ETH) sent by the Vault. Each delta corresponds to the asset at
+     * the same index in the `assets` array.
+     *
+     * Swaps are executed sequentially, in the order specified by the `swaps` array. Each array element describes a
+     * Pool, the token to be sent to this Pool, the token to receive from it, and an amount that is either `amountIn` or
+     * `amountOut` depending on the swap kind.
+     *
+     * Multihop swaps can be executed by passing an `amount` value of zero for a swap. This will cause the amount in/out
+     * of the previous swap to be used as the amount in for the current one. In a 'given in' swap, 'tokenIn' must equal
+     * the previous swap's `tokenOut`. For a 'given out' swap, `tokenOut` must equal the previous swap's `tokenIn`.
+     *
+     * The `assets` array contains the addresses of all assets involved in the swaps. These are either token addresses,
+     * or the IAsset sentinel value for ETH (the zero address). Each entry in the `swaps` array specifies tokens in and
+     * out by referencing an index in `assets`. Note that Pools never interact with ETH directly: it will be wrapped to
+     * or unwrapped from WETH by the Vault.
+     *
+     * Internal Balance usage, sender, and recipient are determined by the `funds` struct. The `limits` array specifies
+     * the minimum or maximum amount of each token the vault is allowed to transfer.
+     *
+     * `batchSwap` can be used to make a single swap, like `swap` does, but doing so requires more gas than the
+     * equivalent `swap` call.
+     *
+     * Emits `Swap` events.
+     */
+    function batchSwap(
+        SwapKind kind,
+        BatchSwapStep[] memory swaps,
+        IAsset[] memory assets,
+        FundManagement memory funds,
+        int256[] memory limits,
+        uint256 deadline
+    ) external payable returns (int256[] memory);
+
+    /**
+     * @dev Data for each individual swap executed by `batchSwap`. The asset in and out fields are indexes into the
+     * `assets` array passed to that function, and ETH assets are converted to WETH.
+     *
+     * If `amount` is zero, the multihop mechanism is used to determine the actual amount based on the amount in/out
+     * from the previous swap, depending on the swap kind.
+     *
+     * The `userData` field is ignored by the Vault, but forwarded to the Pool in the `onSwap` hook, and may be
+     * used to extend swap behavior.
+     */
+    struct BatchSwapStep {
+        bytes32 poolId;
+        uint256 assetInIndex;
+        uint256 assetOutIndex;
+        uint256 amount;
+        bytes userData;
+    }
+
+    /**
+     * @dev Emitted for each individual swap performed by `swap` or `batchSwap`.
+     */
+    event Swap(
+        bytes32 indexed poolId,
+        IERC20 indexed tokenIn,
+        IERC20 indexed tokenOut,
+        uint256 amountIn,
+        uint256 amountOut
+    );
+
+    /**
+     * @dev All tokens in a swap are either sent from the `sender` account to the Vault, or from the Vault to the
+     * `recipient` account.
+     *
+     * If the caller is not `sender`, it must be an authorized relayer for them.
+     *
+     * If `fromInternalBalance` is true, the `sender`'s Internal Balance will be preferred, performing an ERC20
+     * transfer for the difference between the requested amount and the User's Internal Balance (if any). The `sender`
+     * must have allowed the Vault to use their tokens via `IERC20.approve()`. This matches the behavior of
+     * `joinPool`.
+     *
+     * If `toInternalBalance` is true, tokens will be deposited to `recipient`'s internal balance instead of
+     * transferred. This matches the behavior of `exitPool`.
+     *
+     * Note that ETH cannot be deposited to or withdrawn from Internal Balance: attempting to do so will trigger a
+     * revert.
+     */
+    struct FundManagement {
+        address sender;
+        bool fromInternalBalance;
+        address payable recipient;
+        bool toInternalBalance;
+    }
+
+    /**
+     * @dev Simulates a call to `batchSwap`, returning an array of Vault asset deltas. Calls to `swap` cannot be
+     * simulated directly, but an equivalent `batchSwap` call can and will yield the exact same result.
+     *
+     * Each element in the array corresponds to the asset at the same index, and indicates the number of tokens (or ETH)
+     * the Vault would take from the sender (if positive) or send to the recipient (if negative). The arguments it
+     * receives are the same that an equivalent `batchSwap` call would receive.
+     *
+     * Unlike `batchSwap`, this function performs no checks on the sender or recipient field in the `funds` struct.
+     * This makes it suitable to be called by off-chain applications via eth_call without needing to hold tokens,
+     * approve them for the Vault, or even know a user's address.
+     *
+     * Note that this function is not 'view' (due to implementation details): the client code must explicitly execute
+     * eth_call instead of eth_sendTransaction.
+     */
+    function queryBatchSwap(
+        SwapKind kind,
+        BatchSwapStep[] memory swaps,
+        IAsset[] memory assets,
+        FundManagement memory funds
+    ) external returns (int256[] memory assetDeltas);
+
+    // Flash Loans
+
+    /**
+     * @dev Performs a 'flash loan', sending tokens to `recipient`, executing the `receiveFlashLoan` hook on it,
+     * and then reverting unless the tokens plus a proportional protocol fee have been returned.
+     *
+     * The `tokens` and `amounts` arrays must have the same length, and each entry in these indicates the loan amount
+     * for each token contract. `tokens` must be sorted in ascending order.
+     *
+     * The 'userData' field is ignored by the Vault, and forwarded as-is to `recipient` as part of the
+     * `receiveFlashLoan` call.
+     *
+     * Emits `FlashLoan` events.
+     */
+    function flashLoan(
+        IFlashLoanRecipient recipient,
+        IERC20[] memory tokens,
+        uint256[] memory amounts,
+        bytes memory userData
+    ) external;
+
+    /**
+     * @dev Emitted for each individual flash loan performed by `flashLoan`.
+     */
+    event FlashLoan(IFlashLoanRecipient indexed recipient, IERC20 indexed token, uint256 amount, uint256 feeAmount);
+
+    // Asset Management
+    //
+    // Each token registered for a Pool can be assigned an Asset Manager, which is able to freely withdraw the Pool's
+    // tokens from the Vault, deposit them, or assign arbitrary values to its `managed` balance (see
+    // `getPoolTokenInfo`). This makes them extremely powerful and dangerous. Even if an Asset Manager only directly
+    // controls one of the tokens in a Pool, a malicious manager could set that token's balance to manipulate the
+    // prices of the other tokens, and then drain the Pool with swaps. The risk of using Asset Managers is therefore
+    // not constrained to the tokens they are managing, but extends to the entire Pool's holdings.
+    //
+    // However, a properly designed Asset Manager smart contract can be safely used for the Pool's benefit,
+    // for example by lending unused tokens out for interest, or using them to participate in voting protocols.
+    //
+    // This concept is unrelated to the IAsset interface.
+
+    /**
+     * @dev Performs a set of Pool balance operations, which may be either withdrawals, deposits or updates.
+     *
+     * Pool Balance management features batching, which means a single contract call can be used to perform multiple
+     * operations of different kinds, with different Pools and tokens, at once.
+     *
+     * For each operation, the caller must be registered as the Asset Manager for `token` in `poolId`.
+     */
+    function managePoolBalance(PoolBalanceOp[] memory ops) external;
+
+    struct PoolBalanceOp {
+        PoolBalanceOpKind kind;
+        bytes32 poolId;
+        IERC20 token;
+        uint256 amount;
+    }
+
+    /**
+     * Withdrawals decrease the Pool's cash, but increase its managed balance, leaving the total balance unchanged.
+     *
+     * Deposits increase the Pool's cash, but decrease its managed balance, leaving the total balance unchanged.
+     *
+     * Updates don't affect the Pool's cash balance, but because the managed balance changes, it does alter the total.
+     * The external amount can be either increased or decreased by this call (i.e., reporting a gain or a loss).
+     */
+    enum PoolBalanceOpKind { WITHDRAW, DEPOSIT, UPDATE }
+
+    /**
+     * @dev Emitted when a Pool's token Asset Manager alters its balance via `managePoolBalance`.
+     */
+    event PoolBalanceManaged(
+        bytes32 indexed poolId,
+        address indexed assetManager,
+        IERC20 indexed token,
+        int256 cashDelta,
+        int256 managedDelta
+    );
+
+    // Protocol Fees
+    //
+    // Some operations cause the Vault to collect tokens in the form of protocol fees, which can then be withdrawn by
+    // permissioned accounts.
+    //
+    // There are two kinds of protocol fees:
+    //
+    //  - flash loan fees: charged on all flash loans, as a percentage of the amounts lent.
+    //
+    //  - swap fees: a percentage of the fees charged by Pools when performing swaps. For a number of reasons, including
+    // swap gas costs and interface simplicity, protocol swap fees are not charged on each individual swap. Rather,
+    // Pools are expected to keep track of how much they have charged in swap fees, and pay any outstanding debts to the
+    // Vault when they are joined or exited. This prevents users from joining a Pool with unpaid debt, as well as
+    // exiting a Pool in debt without first paying their share.
+
+    /**
+     * @dev Returns the current protocol fee module.
+     */
+    function getProtocolFeesCollector() external view returns (IProtocolFeesCollector);
+
+    /**
+     * @dev Safety mechanism to pause most Vault operations in the event of an emergency - typically detection of an
+     * error in some part of the system.
+     *
+     * The Vault can only be paused during an initial time period, after which pausing is forever disabled.
+     *
+     * While the contract is paused, the following features are disabled:
+     * - depositing and transferring internal balance
+     * - transferring external balance (using the Vault's allowance)
+     * - swaps
+     * - joining Pools
+     * - Asset Manager interactions
+     *
+     * Internal Balance can still be withdrawn, and Pools exited.
+     */
+    function setPaused(bool paused) external;
+
+    /**
+     * @dev Returns the Vault's WETH instance.
+     */
+    function WETH() external view returns (IWETH);
+    // solhint-disable-previous-line func-name-mixedcase
+}

--- a/Interfaces/IWETH.sol
+++ b/Interfaces/IWETH.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity >=0.7.0 <0.9.0;
+
+import "./IERC20.sol"; 
+
+/**
+ * @dev Interface for WETH9.
+ * See https://github.com/gnosis/canonical-weth/blob/0dd1ea3e295eef916d0c6223ec63141137d22d67/contracts/WETH9.sol
+ */
+interface IWETH is IERC20 {
+    function deposit() external payable;
+
+    function withdraw(uint256 amount) external;
+}

--- a/stkSWIV.sol
+++ b/stkSWIV.sol
@@ -15,6 +15,8 @@ contract stkSWIV is ERC20 {
 
     bytes32 public balancerPoolID;
 
+    uint256 public cooldownLength = 2 weeks;
+
     mapping (address => uint256) cooldownTime;
 
     mapping (address => uint256) cooldownAmount;
@@ -76,7 +78,7 @@ contract stkSWIV is ERC20 {
             revert Exception(3, cooldownAmount[msg.sender] + amount, balanceOf[msg.sender], msg.sender, address(0));
         }
         // Reset cooldown time
-        cooldownTime[msg.sender] = block.timestamp + 1209600;
+        cooldownTime[msg.sender] = block.timestamp + cooldownLength;
         // Add the amount;
         cooldownAmount[msg.sender] = cooldownAmount[msg.sender] + amount;
     }

--- a/stkSWIV.sol
+++ b/stkSWIV.sol
@@ -19,6 +19,16 @@ contract stkSWIV is ERC20 {
 
     mapping (address => uint256) cooldownAmount;
 
+    event Deposit(address indexed caller, address indexed owner, uint256 assets, uint256 shares);
+
+    event Withdraw(
+        address indexed caller,
+        address indexed receiver,
+        address indexed owner,
+        uint256 assets,
+        uint256 shares
+    );
+
     error Exception(uint8, uint256, uint256, address, address);
 
     constructor (Vault v, ERC20 s, ERC20 b, bytes32 p) ERC20("Staked SWIV", "stkSWIV", 18) {
@@ -79,6 +89,8 @@ contract stkSWIV is ERC20 {
 
         _mint(receiver, shares);
 
+        emit Deposit(msg.sender, receiver, assets, shares);
+
         return (assets);
     }
 
@@ -87,6 +99,12 @@ contract stkSWIV is ERC20 {
         uint256 assets = convertToAssets(shares);
 
         uint256 cTime = cooldownTime[msg.sender];
+
+        if (msg.sender != owner) {
+            uint256 allowed = allowance[owner][msg.sender];
+
+            if (allowed != type(uint256).max) allowance[owner][msg.sender] = allowed - shares;
+        }
 
         if (cTime > block.timestamp || cTime == 0) {
             revert Exception(0, cTime, block.timestamp, address(0), address(0));
@@ -116,6 +134,8 @@ contract stkSWIV is ERC20 {
 
         _mint(receiver, shares);
 
+        emit Deposit(msg.sender, receiver, assets, shares);
+
         return (shares);
     }
 
@@ -124,6 +144,12 @@ contract stkSWIV is ERC20 {
         uint256 shares = convertToShares(assets);
 
         uint256 cTime = cooldownTime[msg.sender];
+
+        if (msg.sender != owner) {
+            uint256 allowed = allowance[owner][msg.sender];
+
+            if (allowed != type(uint256).max) allowance[owner][msg.sender] = allowed - shares;
+        }
 
         if (cTime > block.timestamp || cTime == 0) {
             revert Exception(0, cTime, block.timestamp, address(0), address(0));
@@ -155,14 +181,22 @@ contract stkSWIV is ERC20 {
 
         _mint(receiver, shares);
 
+        emit Deposit(msg.sender, receiver, assets, shares);
+
         return (assets);
     }
 
-    function redeemZap(uint256 shares, address receiver) public returns (uint256) {
+    function redeemZap(uint256 shares, address receiver, address owner) public returns (uint256) {
 
         uint256 assets = convertToAssets(shares);
 
         uint256 cTime = cooldownTime[msg.sender];
+
+        if (msg.sender != owner) {
+            uint256 allowed = allowance[owner][msg.sender];
+
+            if (allowed != type(uint256).max) allowance[owner][msg.sender] = allowed - shares;
+        }
 
         if (cTime > block.timestamp || cTime == 0) {
             revert Exception(0, cTime, block.timestamp, address(0), address(0));
@@ -198,14 +232,22 @@ contract stkSWIV is ERC20 {
 
         _mint(receiver, shares);
 
+        emit Deposit(msg.sender, receiver, assets, shares);
+
         return (shares);
     }
 
-    function withdrawZap(uint256 assets, address receiver) public returns (uint256) {
+    function withdrawZap(uint256 assets, address receiver, address owner) public returns (uint256) {
 
         uint256 shares = convertToShares(assets);
 
         uint256 cTime = cooldownTime[msg.sender];
+
+        if (msg.sender != owner) {
+            uint256 allowed = allowance[owner][msg.sender];
+
+            if (allowed != type(uint256).max) allowance[owner][msg.sender] = allowed - shares;
+        }
 
         if (cTime > block.timestamp || cTime == 0) {
             revert Exception(0, cTime, block.timestamp, address(0), address(0));

--- a/stkSWIV.sol
+++ b/stkSWIV.sol
@@ -3,62 +3,232 @@ pragma solidity >= 0.8.4;
 
 import './ERC/SolmateERC20.sol';
 import './Utils/SafeTransferLib.sol';
+import './Interfaces/IVault.sol';
 
 contract stkSWIV is ERC20 {
 
-    ERC20 immutable SWIV;
+    ERC20 immutable public SWIV;
 
-    uint256 public totalDeposited;
+    ERC20 immutable public balancerLPT;
 
-    constructor (ERC20 s) ERC20("Staked SWIV", "stkSWIV", 18) {
+    Vault immutable public balancerVault;
+
+    bytes32 public balancerPoolID;
+
+    mapping (address => uint256) cooldownTime;
+
+    mapping (address => uint256) cooldownAmount;
+
+    error Exception(uint8, uint256, uint256, address, address);
+
+    constructor (Vault v, ERC20 s, ERC20 b, bytes32 p) ERC20("Staked SWIV", "stkSWIV", 18) {
+        Vault = v;
         SWIV = s;
+        balancerLPT = b;
+        balancerPoolID = p;
     }
 
+    // The number of SWIV/ETH balancer shares owned / the stkSWIV total supply
+    // Conversion of 1 stkSWIV share to an amount of SWIV/ETH balancer shares (scaled to 1e26) (starts at 1:1e26)
     function exchangeRateCurrent() public view returns (uint256) {
-        return ((SWIV.balanceOf(address(this))*1e26)/totalDeposited);
+        return ((SWIV.balanceOf(address(this)) * 1e26) / this.totalSupply());
     }
 
-    function mint(uint256 amount) public returns (uint256) {
-
-        SafeTransferLib.transferFrom(SWIV, msg.sender, address(this), amount);
-
-        uint256 returned = ((amount * 1e26)/exchangeRateCurrent());
-
-        _mint(msg.sender, returned);
-
-        return (returned);
+    // Conversion of amount of SWIV/ETH balancer shares to stkSWIV shares
+    function convertToShares(uint256 assets) public view returns (uint256 shares) {
+        return ((assets * 1e26) / exchangeRateCurrent());
     }
 
-    function deposit(uint256 amount) public returns (uint256) {
-
-        uint256 sent = (amount * exchangeRateCurrent())/1e26;
-
-        SafeTransferLib.transferFrom(SWIV, msg.sender, address(this), sent);        
-
-        _mint(msg.sender, amount);
-
-        return (amount);
+    function convertToAssets(uint256 shares) public view returns (uint256 assets) {
+        return ((shares * exchangeRateCurrent()) / 1e26);
     }
 
-    function redeemUnderlying(uint256 amount) public returns (uint256) {
-
-        uint256 sent = ((amount * 1e26)/exchangeRateCurrent());
-
-        _burn(msg.sender, sent);
-
-        SafeTransferLib.transfer(SWIV, msg.sender, amount);
-
-        return (amount);
+    function maxMint(address receiver) public view returns (uint256 maxShares) {
+        return (convertToShares(SWIV.balanceOf(receiver)));
     }
 
-    function redeemShares(uint256 amount) public returns (uint256) {
-
-        uint256 returned = (amount * exchangeRateCurrent())/1e26;
-
-        _burn(msg.sender, amount);
-
-        SafeTransferLib.transfer(SWIV, msg.sender, returned);
-
-        return (amount);
+    function maxRedeem(address owner) public view returns (uint256 maxShares) {
+        return (this.balanceOf(owner));
     }
+
+    function maxWithdraw(address owner) public view returns (uint256 maxAssets) {
+        return (convertToAssets(this.balanceOf(owner)));
+    }
+
+    function maxDeposit(address receiver) public view returns (uint256 maxAssets) {
+        return (SWIV.balanceOf(receiver));
+    }
+
+    function cooldown(uint256 amount) public returns (uint256) {
+
+        // Require the total amount to be < balanceOf
+        if (cooldownAmount[msg.sender] + amount > balanceOf[msg.sender]) {
+            revert Exception(3, cooldownAmount[msg.sender] + amount, balanceOf[msg.sender], msg.sender, address(0));
+        }
+        // Reset cooldown time
+        cooldownTime[msg.sender] = block.timestamp + 1209600;
+        // Add the amount;
+        cooldownAmount[msg.sender] = cooldownAmount[msg.sender] + amount;
+    }
+
+    function mint(uint256 shares, address receiver) public payable returns (uint256) {
+
+        uint256 assets = convertToAssets(shares);
+
+        SafeTransferLib.transferFrom(balancerLPT, msg.sender, address(this), assets);
+
+        _mint(receiver, shares);
+
+        return (assets);
+    }
+
+    function redeem(uint256 shares, address receiver) public returns (uint256) {
+
+        uint256 assets = convertToAssets(shares);
+
+        uint256 cTime = cooldownTime[msg.sender];
+
+        if (cTime > block.timestamp || cTime == 0) {
+            revert Exception(0, cTime, block.timestamp, address(0), address(0));
+        }
+
+        uint256 cAmount = cooldownAmount[msg.sender];
+        if (cAmount > assets) {
+            revert Exception(1, cAmount, shares, address(0), address(0));
+        }
+
+        SafeTransferLib.transfer(balancerLPT, receiver, assets);
+
+        _burn(msg.sender, shares);
+
+        cooldownTime[msg.sender] = 0;
+
+        cooldownAmount[msg.sender] = 0;
+
+        return (assets);
+    }
+
+    function deposit(uint256 assets, address receiver) public returns (uint256) {
+
+        uint256 shares = convertToShares(assets);
+
+        SafeTransferLib.transferFrom(SWIV, msg.sender, address(this), assets);        
+
+        _mint(receiver, shares);
+
+        return (shares);
+    }
+
+    function withdraw(uint256 assets, address receiver) public returns (uint256) {
+
+        uint256 shares = convertToShares(assets);
+
+        uint256 cTime = cooldownTime[msg.sender];
+
+        if (cTime > block.timestamp || cTime == 0) {
+            revert Exception(0, cTime, block.timestamp, address(0), address(0));
+        }
+
+        uint256 cAmount = cooldownAmount[msg.sender];
+        if (cAmount > assets) {
+            revert Exception(1, cAmount, shares, address(0), address(0));
+        }
+
+        SafeTransferLib.transfer(balancerLPT, receiver, assets);
+
+        _burn(msg.sender, shares);
+
+        cooldownTime[msg.sender] = 0;
+
+        cooldownAmount[msg.sender] = 0;
+
+        return (shares);
+    }
+
+    function mintZap(uint256 shares, address receiver) public payable returns (uint256) {
+
+        uint256 assets = convertToAssets(shares);
+
+        SafeTransferLib.transferFrom(balancerLPT, msg.sender, address(this), assets);
+
+        // Todo: balancer tx
+
+        _mint(receiver, shares);
+
+        return (assets);
+    }
+
+    function redeemZap(uint256 shares, address receiver) public returns (uint256) {
+
+        uint256 assets = convertToAssets(shares);
+
+        uint256 cTime = cooldownTime[msg.sender];
+
+        if (cTime > block.timestamp || cTime == 0) {
+            revert Exception(0, cTime, block.timestamp, address(0), address(0));
+        }
+
+        uint256 cAmount = cooldownAmount[msg.sender];
+        if (cAmount > assets) {
+            revert Exception(1, cAmount, shares, address(0), address(0));
+        }
+
+        // Todo: balancer tx
+
+        SafeTransferLib.transfer(balancerLPT, receiver, assets);
+
+        // Todo: ETH transfer
+
+        _burn(msg.sender, shares);
+
+        cooldownTime[msg.sender] = 0;
+
+        cooldownAmount[msg.sender] = 0;
+
+        return (assets);
+    }
+
+    function depositZap(uint256 assets, address receiver) public payable returns (uint256) {
+
+        uint256 shares = convertToShares(assets);
+
+        SafeTransferLib.transferFrom(SWIV, msg.sender, address(this), assets);        
+
+        // Todo: balancer tx
+
+        _mint(receiver, shares);
+
+        return (shares);
+    }
+
+    function withdrawZap(uint256 assets, address receiver) public returns (uint256) {
+
+        uint256 shares = convertToShares(assets);
+
+        uint256 cTime = cooldownTime[msg.sender];
+
+        if (cTime > block.timestamp || cTime == 0) {
+            revert Exception(0, cTime, block.timestamp, address(0), address(0));
+        }
+
+        uint256 cAmount = cooldownAmount[msg.sender];
+        if (cAmount > assets) {
+            revert Exception(1, cAmount, shares, address(0), address(0));
+        }
+
+        // Todo: balancer tx
+
+        SafeTransferLib.transfer(balancerLPT, receiver, assets);
+
+        // Todo: ETH transfer
+
+        _burn(msg.sender, shares);
+
+        cooldownTime[msg.sender] = 0;
+
+        cooldownAmount[msg.sender] = 0;
+
+        return (shares);
+    }
+
 }

--- a/stkSWIV.sol
+++ b/stkSWIV.sol
@@ -56,7 +56,7 @@ contract stkSWIV is ERC20 {
     }
 
     function maxMint(address receiver) public view returns (uint256 maxShares) {
-        return (convertToShares(SWIV.balanceOf(receiver)));
+        return type(uint256).max;
     }
 
     function maxRedeem(address owner) public view returns (uint256 maxShares) {
@@ -68,7 +68,7 @@ contract stkSWIV is ERC20 {
     }
 
     function maxDeposit(address receiver) public view returns (uint256 maxAssets) {
-        return (SWIV.balanceOf(receiver));
+        return type(uint256).max;
     }
 
     function cooldown(uint256 amount) public returns (uint256) {

--- a/stkSWIV.sol
+++ b/stkSWIV.sol
@@ -123,6 +123,8 @@ contract stkSWIV is ERC20 {
 
         cooldownAmount[msg.sender] = 0;
 
+        emit Withdraw(msg.sender, receiver, owner, assets, shares);
+
         return (assets);
     }
 
@@ -167,6 +169,8 @@ contract stkSWIV is ERC20 {
         cooldownTime[msg.sender] = 0;
 
         cooldownAmount[msg.sender] = 0;
+
+        emit Withdraw(msg.sender, receiver, owner, assets, shares);
 
         return (shares);
     }
@@ -219,6 +223,8 @@ contract stkSWIV is ERC20 {
 
         cooldownAmount[msg.sender] = 0;
 
+        emit Withdraw(msg.sender, receiver, owner, assets, shares);
+
         return (assets);
     }
 
@@ -269,6 +275,8 @@ contract stkSWIV is ERC20 {
         cooldownTime[msg.sender] = 0;
 
         cooldownAmount[msg.sender] = 0;
+
+        emit Withdraw(msg.sender, receiver, owner, assets, shares);
 
         return (shares);
     }


### PR DESCRIPTION
This should wrap up the SSM for now outside of the actual transactions with balancer.

The "underlying asset" of the SSM is then the balancer LP token, with the "share" then being the stkSWIV token (the SSM itself)

- Cooldown of 2 weeks
- Full 4626 functionality
- Extra "zap" methods for those that do not own a balancer LP token (but do own SWIV and ETH)

