### PR TITLE
4626 inflation fixes

### DIFF
--- a/Utils/FixedPointMathLib.sol
+++ b/Utils/FixedPointMathLib.sol
@@ -1,0 +1,255 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity >=0.8.0;
+
+/// @notice Arithmetic library with operations for fixed-point numbers.
+/// @author Solmate (https://github.com/transmissions11/solmate/blob/main/src/utils/FixedPointMathLib.sol)
+/// @author Inspired by USM (https://github.com/usmfum/USM/blob/master/contracts/WadMath.sol)
+library FixedPointMathLib {
+    /*//////////////////////////////////////////////////////////////
+                    SIMPLIFIED FIXED POINT OPERATIONS
+    //////////////////////////////////////////////////////////////*/
+
+    uint256 internal constant MAX_UINT256 = 2**256 - 1;
+
+    uint256 internal constant WAD = 1e18; // The scalar of ETH and most ERC20s.
+
+    function mulWadDown(uint256 x, uint256 y) internal pure returns (uint256) {
+        return mulDivDown(x, y, WAD); // Equivalent to (x * y) / WAD rounded down.
+    }
+
+    function mulWadUp(uint256 x, uint256 y) internal pure returns (uint256) {
+        return mulDivUp(x, y, WAD); // Equivalent to (x * y) / WAD rounded up.
+    }
+
+    function divWadDown(uint256 x, uint256 y) internal pure returns (uint256) {
+        return mulDivDown(x, WAD, y); // Equivalent to (x * WAD) / y rounded down.
+    }
+
+    function divWadUp(uint256 x, uint256 y) internal pure returns (uint256) {
+        return mulDivUp(x, WAD, y); // Equivalent to (x * WAD) / y rounded up.
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                    LOW LEVEL FIXED POINT OPERATIONS
+    //////////////////////////////////////////////////////////////*/
+
+    function mulDivDown(
+        uint256 x,
+        uint256 y,
+        uint256 denominator
+    ) internal pure returns (uint256 z) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            // Equivalent to require(denominator != 0 && (y == 0 || x <= type(uint256).max / y))
+            if iszero(mul(denominator, iszero(mul(y, gt(x, div(MAX_UINT256, y)))))) {
+                revert(0, 0)
+            }
+
+            // Divide x * y by the denominator.
+            z := div(mul(x, y), denominator)
+        }
+    }
+
+    function mulDivUp(
+        uint256 x,
+        uint256 y,
+        uint256 denominator
+    ) internal pure returns (uint256 z) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            // Equivalent to require(denominator != 0 && (y == 0 || x <= type(uint256).max / y))
+            if iszero(mul(denominator, iszero(mul(y, gt(x, div(MAX_UINT256, y)))))) {
+                revert(0, 0)
+            }
+
+            // If x * y modulo the denominator is strictly greater than 0,
+            // 1 is added to round up the division of x * y by the denominator.
+            z := add(gt(mod(mul(x, y), denominator), 0), div(mul(x, y), denominator))
+        }
+    }
+
+    function rpow(
+        uint256 x,
+        uint256 n,
+        uint256 scalar
+    ) internal pure returns (uint256 z) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            switch x
+            case 0 {
+                switch n
+                case 0 {
+                    // 0 ** 0 = 1
+                    z := scalar
+                }
+                default {
+                    // 0 ** n = 0
+                    z := 0
+                }
+            }
+            default {
+                switch mod(n, 2)
+                case 0 {
+                    // If n is even, store scalar in z for now.
+                    z := scalar
+                }
+                default {
+                    // If n is odd, store x in z for now.
+                    z := x
+                }
+
+                // Shifting right by 1 is like dividing by 2.
+                let half := shr(1, scalar)
+
+                for {
+                    // Shift n right by 1 before looping to halve it.
+                    n := shr(1, n)
+                } n {
+                    // Shift n right by 1 each iteration to halve it.
+                    n := shr(1, n)
+                } {
+                    // Revert immediately if x ** 2 would overflow.
+                    // Equivalent to iszero(eq(div(xx, x), x)) here.
+                    if shr(128, x) {
+                        revert(0, 0)
+                    }
+
+                    // Store x squared.
+                    let xx := mul(x, x)
+
+                    // Round to the nearest number.
+                    let xxRound := add(xx, half)
+
+                    // Revert if xx + half overflowed.
+                    if lt(xxRound, xx) {
+                        revert(0, 0)
+                    }
+
+                    // Set x to scaled xxRound.
+                    x := div(xxRound, scalar)
+
+                    // If n is even:
+                    if mod(n, 2) {
+                        // Compute z * x.
+                        let zx := mul(z, x)
+
+                        // If z * x overflowed:
+                        if iszero(eq(div(zx, x), z)) {
+                            // Revert if x is non-zero.
+                            if iszero(iszero(x)) {
+                                revert(0, 0)
+                            }
+                        }
+
+                        // Round to the nearest number.
+                        let zxRound := add(zx, half)
+
+                        // Revert if zx + half overflowed.
+                        if lt(zxRound, zx) {
+                            revert(0, 0)
+                        }
+
+                        // Return properly scaled zxRound.
+                        z := div(zxRound, scalar)
+                    }
+                }
+            }
+        }
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                        GENERAL NUMBER UTILITIES
+    //////////////////////////////////////////////////////////////*/
+
+    function sqrt(uint256 x) internal pure returns (uint256 z) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            let y := x // We start y at x, which will help us make our initial estimate.
+
+            z := 181 // The "correct" value is 1, but this saves a multiplication later.
+
+            // This segment is to get a reasonable initial estimate for the Babylonian method. With a bad
+            // start, the correct # of bits increases ~linearly each iteration instead of ~quadratically.
+
+            // We check y >= 2^(k + 8) but shift right by k bits
+            // each branch to ensure that if x >= 256, then y >= 256.
+            if iszero(lt(y, 0x10000000000000000000000000000000000)) {
+                y := shr(128, y)
+                z := shl(64, z)
+            }
+            if iszero(lt(y, 0x1000000000000000000)) {
+                y := shr(64, y)
+                z := shl(32, z)
+            }
+            if iszero(lt(y, 0x10000000000)) {
+                y := shr(32, y)
+                z := shl(16, z)
+            }
+            if iszero(lt(y, 0x1000000)) {
+                y := shr(16, y)
+                z := shl(8, z)
+            }
+
+            // Goal was to get z*z*y within a small factor of x. More iterations could
+            // get y in a tighter range. Currently, we will have y in [256, 256*2^16).
+            // We ensured y >= 256 so that the relative difference between y and y+1 is small.
+            // That's not possible if x < 256 but we can just verify those cases exhaustively.
+
+            // Now, z*z*y <= x < z*z*(y+1), and y <= 2^(16+8), and either y >= 256, or x < 256.
+            // Correctness can be checked exhaustively for x < 256, so we assume y >= 256.
+            // Then z*sqrt(y) is within sqrt(257)/sqrt(256) of sqrt(x), or about 20bps.
+
+            // For s in the range [1/256, 256], the estimate f(s) = (181/1024) * (s+1) is in the range
+            // (1/2.84 * sqrt(s), 2.84 * sqrt(s)), with largest error when s = 1 and when s = 256 or 1/256.
+
+            // Since y is in [256, 256*2^16), let a = y/65536, so that a is in [1/256, 256). Then we can estimate
+            // sqrt(y) using sqrt(65536) * 181/1024 * (a + 1) = 181/4 * (y + 65536)/65536 = 181 * (y + 65536)/2^18.
+
+            // There is no overflow risk here since y < 2^136 after the first branch above.
+            z := shr(18, mul(z, add(y, 65536))) // A mul() is saved from starting z at 181.
+
+            // Given the worst case multiplicative error of 2.84 above, 7 iterations should be enough.
+            z := shr(1, add(z, div(x, z)))
+            z := shr(1, add(z, div(x, z)))
+            z := shr(1, add(z, div(x, z)))
+            z := shr(1, add(z, div(x, z)))
+            z := shr(1, add(z, div(x, z)))
+            z := shr(1, add(z, div(x, z)))
+            z := shr(1, add(z, div(x, z)))
+
+            // If x+1 is a perfect square, the Babylonian method cycles between
+            // floor(sqrt(x)) and ceil(sqrt(x)). This statement ensures we return floor.
+            // See: https://en.wikipedia.org/wiki/Integer_square_root#Using_only_integer_division
+            // Since the ceil is rare, we save gas on the assignment and repeat division in the rare case.
+            // If you don't care whether the floor or ceil square root is returned, you can remove this statement.
+            z := sub(z, lt(div(x, z), z))
+        }
+    }
+
+    function unsafeMod(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            // Mod x by y. Note this will return
+            // 0 instead of reverting if y is zero.
+            z := mod(x, y)
+        }
+    }
+
+    function unsafeDiv(uint256 x, uint256 y) internal pure returns (uint256 r) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            // Divide x by y. Note this will return
+            // 0 instead of reverting if y is zero.
+            r := div(x, y)
+        }
+    }
+
+    function unsafeDivUp(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            // Add 1 to x * y if x % y > 0. Note this will
+            // return 0 instead of reverting if y is zero.
+            z := add(gt(mod(x, y), 0), div(x, y))
+        }
+    }
+}

--- a/Utils/FixedPointMathLib.sol
+++ b/Utils/FixedPointMathLib.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity >=0.8.0;
+pragma solidity >=0.8.4;
 
 /// @notice Arithmetic library with operations for fixed-point numbers.
 /// @author Solmate (https://github.com/transmissions11/solmate/blob/main/src/utils/FixedPointMathLib.sol)

--- a/stkSWIV.sol
+++ b/stkSWIV.sol
@@ -44,6 +44,10 @@ contract stkSWIV is ERC20 {
         SafeTransferLib.approve(SWIV, address(balancerLPT), type(uint256).max);
     }
 
+    function asset() public view returns (address) {
+        return (address(balancerLPT));
+    }
+
     function totalAssets() public view returns (uint256 assets) {
         return (balancerLPT.balanceOf(address(this)));
     }

--- a/stkSWIV.sol
+++ b/stkSWIV.sol
@@ -78,8 +78,6 @@ contract stkSWIV is ERC20 {
         uint256 supply = this.totalSupply();
         return supply == 0 ? shares : shares.mulDivDown(totalAssets() + 1, supply + 1e18);
     }
-    
-    }
 
     // Maximum amount a given receiver can mint
     // @param: receiver - address of the receiver

--- a/stkSWIV.sol
+++ b/stkSWIV.sol
@@ -35,7 +35,7 @@ contract stkSWIV is ERC20 {
 
     error Exception(uint8, uint256, uint256, address, address);
 
-    constructor (ERC20 s, IVault v, ERC20 b, bytes32 p) ERC20("Staked SWIV/ETH", "stkSWIV", 36) {
+    constructor (ERC20 s, IVault v, ERC20 b, bytes32 p) ERC20("Staked SWIV/ETH", "stkSWIV", s.decimals() + 18) {
         SWIV = s;
         balancerVault = v;
         balancerLPT = b;

--- a/stkSWIV.sol
+++ b/stkSWIV.sol
@@ -78,7 +78,7 @@ contract stkSWIV is ERC20 {
     // @returns: the amount of SWIV/ETH balancer pool tokens
     function convertToAssets(uint256 shares) public view returns (uint256 assets) {
         uint256 supply = this.totalSupply();
-        return supply == 0 ? shares : shares.mulDivDown(totalAssets() + 1, supply + 1e18);
+        return (supply == 0 ? shares : shares.mulDivDown(totalAssets() + 1, supply + 1e18));
     }
 
     // Preview of the amount of balancerLPT required to mint `shares` of stkSWIV
@@ -87,21 +87,21 @@ contract stkSWIV is ERC20 {
     function previewMint(uint256 shares) public view virtual returns (uint256 assets) {
         uint256 supply = totalSupply; // Saves an extra SLOAD if totalSupply is non-zero.
 
-        return supply == 0 ? shares : shares.mulDivUp(totalAssets() + 1, supply + 1e18);
+        return (supply == 0 ? shares : shares.mulDivUp(totalAssets() + 1, supply + 1e18));
     }
 
     // Preview of the amount of balancerLPT received from redeeming `shares` of stkSWIV
     // @param: shares - amount of stkSWIV shares
     // @returns: assets the amount of balancerLPT tokens received
     function previewRedeem(uint256 shares) public view virtual returns (uint256 assets) {
-        return convertToAssets(shares);
+        return (convertToAssets(shares));
     }
 
     // Preview of the amount of stkSWIV received from depositing `assets` of balancerLPT
     // @param: assets - amount of balancerLPT tokens
     // @returns: shares the amount of stkSWIV shares received
     function previewDeposit(uint256 assets) public view virtual returns (uint256 shares) {
-        return convertToShares(assets);
+        return (convertToShares(assets));
     }
 
     // Preview of the amount of stkSWIV required to withdraw `assets` of balancerLPT
@@ -110,14 +110,14 @@ contract stkSWIV is ERC20 {
     function previewWithdraw(uint256 assets) public view virtual returns (uint256 shares) {
         uint256 supply = totalSupply; // Saves an extra SLOAD if totalSupply is non-zero.
 
-        return supply == 0 ? assets : assets.mulDivUp(supply + 1e18, totalAssets() + 1);
+        return (supply == 0 ? assets : assets.mulDivUp(supply + 1e18, totalAssets() + 1));
     }
 
     // Maximum amount a given receiver can mint
     // @param: receiver - address of the receiver
     // @returns: the maximum amount of stkSWIV shares
     function maxMint(address receiver) public pure returns (uint256 maxShares) {
-        return type(uint256).max;
+        return (type(uint256).max);
     }
 
     // Maximum amount a given owner can redeem
@@ -138,14 +138,13 @@ contract stkSWIV is ERC20 {
     // @param: receiver - address of the receiver
     // @returns: the maximum amount of balancerLPT assets
     function maxDeposit(address receiver) public pure returns (uint256 maxAssets) {
-        return type(uint256).max;
+        return (type(uint256).max);
     }
 
     // Queues `amount` of balancerLPT assets to be withdrawn after the cooldown period
     // @param: amount - amount of balancerLPT assets to be withdrawn
     // @returns: the total amount of balancerLPT assets to be withdrawn
     function cooldown(uint256 amount) public returns (uint256) {
-
         // Require the total amount to be < balanceOf
         if (cooldownAmount[msg.sender] + amount > balanceOf[msg.sender]) {
             revert Exception(3, cooldownAmount[msg.sender] + amount, balanceOf[msg.sender], msg.sender, address(0));

--- a/stkSWIV.sol
+++ b/stkSWIV.sol
@@ -70,7 +70,7 @@ contract stkSWIV is ERC20 {
     // @returns: the amount of stkSWIV shares
     function convertToShares(uint256 assets) public view returns (uint256 shares) {
         uint256 supply = this.totalSupply();
-        return (supply == 0 ? assets : assets.mulDivDown(this.totalSupply() + 1e18, totalAssets() + 1));
+        return (assets.mulDivDown(this.totalSupply() + 1e18, totalAssets() + 1));
     }
 
     // Conversion of amount of stkSWIV shares to SWIV/ETH balancer assets
@@ -78,7 +78,7 @@ contract stkSWIV is ERC20 {
     // @returns: the amount of SWIV/ETH balancer pool tokens
     function convertToAssets(uint256 shares) public view returns (uint256 assets) {
         uint256 supply = this.totalSupply();
-        return (supply == 0 ? shares : shares.mulDivDown(totalAssets() + 1, supply + 1e18));
+        return (shares.mulDivDown(totalAssets() + 1, supply + 1e18));
     }
 
     // Preview of the amount of balancerLPT required to mint `shares` of stkSWIV
@@ -87,7 +87,7 @@ contract stkSWIV is ERC20 {
     function previewMint(uint256 shares) public view virtual returns (uint256 assets) {
         uint256 supply = totalSupply; // Saves an extra SLOAD if totalSupply is non-zero.
 
-        return (supply == 0 ? shares : shares.mulDivUp(totalAssets() + 1, supply + 1e18));
+        return (shares.mulDivUp(totalAssets() + 1, supply + 1e18));
     }
 
     // Preview of the amount of balancerLPT received from redeeming `shares` of stkSWIV
@@ -110,7 +110,7 @@ contract stkSWIV is ERC20 {
     function previewWithdraw(uint256 assets) public view virtual returns (uint256 shares) {
         uint256 supply = totalSupply; // Saves an extra SLOAD if totalSupply is non-zero.
 
-        return (supply == 0 ? assets : assets.mulDivUp(supply + 1e18, totalAssets() + 1));
+        return (assets.mulDivUp(supply + 1e18, totalAssets() + 1));
     }
 
     // Maximum amount a given receiver can mint

--- a/stkSWIV.sol
+++ b/stkSWIV.sol
@@ -3,9 +3,12 @@ pragma solidity >= 0.8.4;
 
 import './ERC/SolmateERC20.sol';
 import './Utils/SafeTransferLib.sol';
+import './Utils/FixedPointMathLib.sol';
 import './Interfaces/IVault.sol';
 
 contract stkSWIV is ERC20 {
+    using FixedPointMathLib for uint256;
+
     // The Swivel Multisig (or should be)
     address public admin;
     // The Swivel Token
@@ -64,14 +67,18 @@ contract stkSWIV is ERC20 {
     // @param: assets - amount of SWIV/ETH balancer pool tokens
     // @returns: the amount of stkSWIV shares
     function convertToShares(uint256 assets) public view returns (uint256 shares) {
-        return (assets) * exchangeRateCurrent();
+        uint256 supply = this.totalSupply();
+        return (supply == 0 ? assets : assets.mulDivDown(this.totalSupply() + 1e18, totalAssets() + 1));
     }
 
     // Conversion of amount of stkSWIV shares to SWIV/ETH balancer assets
     // @param: shares - amount of stkSWIV shares
     // @returns: the amount of SWIV/ETH balancer pool tokens
     function convertToAssets(uint256 shares) public view returns (uint256 assets) {
-        return (shares / exchangeRateCurrent());
+        uint256 supply = this.totalSupply();
+        return supply == 0 ? shares : shares.mulDivDown(totalAssets() + 1, supply + 1e18);
+    }
+    
     }
 
     // Maximum amount a given receiver can mint


### PR DESCRIPTION
I *believe* this sufficiently fixes the 4626 inflation attack --

I added an offset of 18 decimals between the asset <> shares, and included a base virtual balance of 1 share = 1e18 assets in the pool.

This appears to follow the suggested remediation -- 
Ethereum Magicians Thread -- https://ethereum-magicians.org/t/address-eip-4626-inflation-attacks-with-virtual-shares-and-assets/12677

Example remediation from OZ -- https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/extensions/ERC4626.sol#L229

I may come back and use their math package to add precision and increase confidence.

