### PR TITLE
return leftover balances on deposit & mint operations

### DIFF
--- a/stkSWIV.sol
+++ b/stkSWIV.sol
@@ -304,16 +304,16 @@ contract stkSWIV is ERC20 {
         // Mint shares to receiver
         _mint(receiver, shares);
 
-        // If there is any leftover SWIV, transfer it to the receiver
+        // If there is any leftover SWIV, transfer it to the msg.sender
         uint256 swivBalance = SWIV.balanceOf(address(this));
         if (swivBalance > 0) {
             // Transfer the SWIV to the receiver
-            SafeTransferLib.transfer(SWIV, receiver, swivBalance);
+            SafeTransferLib.transfer(SWIV, msg.sender, swivBalance);
         }
-        // If there is any leftover ETH, transfer it to the receiver
+        // If there is any leftover ETH, transfer it to the msg.sender
         if (address(this).balance > 0) {
             // Transfer the ETH to the receiver
-            payable(receiver).transfer(address(this).balance);
+            payable(msg.sender).transfer(address(this).balance);
         }
 
         // Emit deposit event
@@ -416,16 +416,16 @@ contract stkSWIV is ERC20 {
         // Mint shares to receiver
         _mint(receiver, shares);
 
-        // If there is any leftover SWIV, transfer it to the receiver
+        // If there is any leftover SWIV, transfer it to the msg.sender
         uint256 swivBalance = SWIV.balanceOf(address(this));
         if (swivBalance > 0) {
             // Transfer the SWIV to the receiver
-            SafeTransferLib.transfer(SWIV, receiver, swivBalance);
+            SafeTransferLib.transfer(SWIV, msg.sender, swivBalance);
         }
-        // If there is any leftover ETH, transfer it to the receiver
+        // If there is any leftover ETH, transfer it to the msg.sender
         if (address(this).balance > 0) {
             // Transfer the ETH to the receiver
-            payable(receiver).transfer(address(this).balance);
+            payable(msg.sender).transfer(address(this).balance);
         }
 
         // Emit deposit event

--- a/stkSWIV.sol
+++ b/stkSWIV.sol
@@ -27,6 +27,8 @@ contract stkSWIV is ERC20 {
     mapping (address => uint256) cooldownTime;
     // Mapping of user address -> amount of balancerLPT assets to be withdrawn
     mapping (address => uint256) cooldownAmount;
+    // Determines whether the contract is paused or not
+    bool public paused;
 
     event Deposit(address indexed caller, address indexed owner, uint256 assets, uint256 shares);
 
@@ -173,7 +175,7 @@ contract stkSWIV is ERC20 {
     // @param: receiver - address of the receiver
     // @param: owner - address of the owner
     // @returns: the amount of balancerLPT tokens withdrawn
-    function redeem(uint256 shares, address receiver, address owner) public returns (uint256) {
+    function redeem(uint256 shares, address receiver, address owner) Unpaused() public returns (uint256) {
         // Convert shares to assets
         uint256 assets = convertToAssets(shares);
         // Get the cooldown time
@@ -233,7 +235,7 @@ contract stkSWIV is ERC20 {
     // @param: receiver - address of the receiver
     // @param: owner - address of the owner
     // @returns: the amount of stkSWIV shares withdrawn
-    function withdraw(uint256 assets, address receiver, address owner) public returns (uint256) {
+    function withdraw(uint256 assets, address receiver, address owner) Unpaused()  public returns (uint256) {
         // Convert assets to shares
         uint256 shares = convertToShares(assets);
         // Get the cooldown time
@@ -325,7 +327,7 @@ contract stkSWIV is ERC20 {
     // @param: receiver - address of the receiver
     // @param: owner - address of the owner
     // @returns: the amount of SWIV tokens withdrawn
-    function redeemZap(uint256 shares, address payable receiver, address owner) public returns (uint256) {
+    function redeemZap(uint256 shares, address payable receiver, address owner) Unpaused()  public returns (uint256) {
         // Convert shares to assets
         uint256 assets = convertToAssets(shares);
         // Get the cooldown time
@@ -378,7 +380,7 @@ contract stkSWIV is ERC20 {
         cooldownAmount[msg.sender] = 0;
         // Emit withdraw event
         emit Withdraw(msg.sender, receiver, owner, assets, shares);
-        
+
         return (assets);
     }
 
@@ -435,7 +437,7 @@ contract stkSWIV is ERC20 {
     // @param: receiver - address of the receiver
     // @param: owner - address of the owner
     // @returns: the amount of stkSWIV shares burnt
-    function withdrawZap(uint256 assets, address payable receiver, address owner) public returns (uint256) {
+    function withdrawZap(uint256 assets, address payable receiver, address owner) Unpaused() public returns (uint256) {
         // Convert assets to shares
         uint256 shares = convertToShares(assets);
         // Get the cooldown time
@@ -518,9 +520,20 @@ contract stkSWIV is ERC20 {
         admin = _admin;
     }
 
+    // Pauses all withdrawing
+    function pause() Authorized(admin) public {
+        paused = true;
+    }
+
     // Authorized modifier
     modifier Authorized(address) {
         require(msg.sender == admin || msg.sender == address(this), "Not authorized");
+        _;
+    }
+
+    // Unpaused modifier
+    modifier Unpaused() {
+        require(!paused, "Paused");
         _;
     }
 }

--- a/stkSWIV.sol
+++ b/stkSWIV.sol
@@ -283,7 +283,6 @@ contract stkSWIV is ERC20 {
         uint256 assets = convertToAssets(shares);
         // Transfer assets of SWIV tokens from sender to this contract
         SafeTransferLib.transferFrom(SWIV, msg.sender, address(this), assets);
-
         // Instantiate balancer request struct using SWIV and ETH alongside the amounts sent
         IAsset[] memory assetData;
         assetData[0] = IAsset(address(SWIV));
@@ -303,7 +302,6 @@ contract stkSWIV is ERC20 {
         IVault(balancerVault).joinPool(balancerPoolID, address(this), address(this), requestData);
         // Mint shares to receiver
         _mint(receiver, shares);
-
         // If there is any leftover SWIV, transfer it to the msg.sender
         uint256 swivBalance = SWIV.balanceOf(address(this));
         if (swivBalance > 0) {
@@ -315,7 +313,6 @@ contract stkSWIV is ERC20 {
             // Transfer the ETH to the receiver
             payable(msg.sender).transfer(address(this).balance);
         }
-
         // Emit deposit event
         emit Deposit(msg.sender, receiver, assets, shares);
 
@@ -381,7 +378,7 @@ contract stkSWIV is ERC20 {
         cooldownAmount[msg.sender] = 0;
         // Emit withdraw event
         emit Withdraw(msg.sender, receiver, owner, assets, shares);
-
+        
         return (assets);
     }
 
@@ -415,7 +412,6 @@ contract stkSWIV is ERC20 {
         IVault(balancerVault).joinPool(balancerPoolID, address(this), address(this), requestData);
         // Mint shares to receiver
         _mint(receiver, shares);
-
         // If there is any leftover SWIV, transfer it to the msg.sender
         uint256 swivBalance = SWIV.balanceOf(address(this));
         if (swivBalance > 0) {
@@ -427,7 +423,6 @@ contract stkSWIV is ERC20 {
             // Transfer the ETH to the receiver
             payable(msg.sender).transfer(address(this).balance);
         }
-
         // Emit deposit event
         emit Deposit(msg.sender, receiver, assets, shares);
 


### PR DESCRIPTION
- Minor gas optimizations (Aleksa's comment from last PR)
- Return any leftover balances when using `depositZap` and `mintZap` to the msg.sender 