### PR TITLE
Zap tests

### DIFF
--- a/src/Interfaces/IQuery.sol
+++ b/src/Interfaces/IQuery.sol
@@ -21,4 +21,10 @@ interface IQuery {
             address sender,
             address recipient,
             IVault.JoinPoolRequest memory request) external returns (uint256 bptOut, uint256[] memory amountsIn);
+
+    function queryExit(
+        bytes32 poolId,
+        address sender,
+        address recipient,
+        IVault.ExitPoolRequest memory request) external returns (uint256 bptIn, uint256[] memory amountsOut);
 }

--- a/test/Contract.t.sol
+++ b/test/Contract.t.sol
@@ -260,11 +260,21 @@ contract SSMTest is Test {
         vm.startPrank(Constants.userPublicKey);
         uint256 amount = 697377559108214882330512;
         (uint256 minBPT,uint256 sharesMinted) = SSM.mintZap{value: 1 ether}(amount, Constants.userPublicKey);
-        console.log("LPT Balance: ", LPT.balanceOf(address(SSM)));
-        console.log("Shares Minted: ", sharesMinted);
-        console.log("Total Supply", SSM.totalSupply());
         SSM.cooldown(sharesMinted);
         vm.warp(block.timestamp + SSM.cooldownLength());
         SSM.redeemZap(sharesMinted, payable(Constants.userPublicKey), Constants.userPublicKey); 
+    }
+
+    function testWithdrawZap() public {
+        vm.startPrank(Constants.userPublicKey);
+        uint256 amount = startingBalance / 2;
+        (uint256 sharesMinted, uint256 swivDeposited) = SSM.depositZap{value: 1 ether}(amount, Constants.userPublicKey);
+        console.log("Shares Minted: ", sharesMinted);
+        console.log("Swiv Deposited: ", swivDeposited);
+        SSM.cooldown(sharesMinted);
+        vm.warp(block.timestamp + SSM.cooldownLength());
+        (uint256 sharesBurnt, uint256 swivReturned) = SSM.withdrawZap(swivDeposited, payable(Constants.userPublicKey), Constants.userPublicKey); 
+        console.log("Shares Burnt: ", sharesBurnt);
+        console.log("Swiv Returned: ", swivReturned);
     }
 }

--- a/test/Contract.t.sol
+++ b/test/Contract.t.sol
@@ -60,6 +60,7 @@ contract SSMTest is Test {
         SSM.deposit(amount, Constants.userPublicKey);
         assertEq(LPT.balanceOf(Constants.userPublicKey), amount);
         assertEq(SSM.balanceOf(Constants.userPublicKey), amount*1e18);
+        assertEq(SSM.totalSupply(), amount*1e18);
     }
 
     function testFirstMint() public {
@@ -68,6 +69,7 @@ contract SSMTest is Test {
         SSM.mint(amount*1e18, Constants.userPublicKey);
         assertEq(LPT.balanceOf(Constants.userPublicKey), amount);
         assertEq(SSM.balanceOf(Constants.userPublicKey), amount*1e18);
+        assertEq(SSM.totalSupply(), amount*1e18);
     }
 
     function testCooldown() public {

--- a/test/Contract.t.sol
+++ b/test/Contract.t.sol
@@ -238,7 +238,8 @@ contract SSMTest is Test {
         vm.startPrank(Constants.userPublicKey);
         uint256 amount = 597377559108214882330512;
         uint256 previousLPTBalance = LPT.balanceOf(address(SSM));
-        SSM.mintZap{value: 1 ether}(amount, Constants.userPublicKey); 
+        SSM.mintZap{value: 1 ether}(amount, Constants.userPublicKey);
+        assertGe(SSM.balanceOf(address(Constants.userPublicKey)), amount);
         console.log("LPT Balance: ", LPT.balanceOf(address(SSM)));
         assertGt(LPT.balanceOf(address(SSM)), previousLPTBalance);
         assertEq(BAL.balanceOf(address(SSM)), 0);
@@ -251,5 +252,14 @@ contract SSMTest is Test {
         uint256 previousLPTBalance = LPT.balanceOf(address(SSM));
         vm.expectRevert();
         SSM.mintZap{value: 1 ether}(amount, Constants.userPublicKey); 
+    }
+
+    function testRedeemZap() public {
+        vm.startPrank(Constants.userPublicKey);
+        uint256 amount = 697377559108214882330512;
+        uint256 assetsUsedForMint = SSM.mintZap{value: 1 ether}(amount, Constants.userPublicKey);
+        SSM.cooldown(assetsUsedForMint);
+        vm.warp(block.timestamp+ SSM.cooldownLength());
+        SSM.redeemZap(amount, payable(Constants.userPublicKey), Constants.userPublicKey); 
     }
 }

--- a/test/Contract.t.sol
+++ b/test/Contract.t.sol
@@ -33,7 +33,6 @@ contract SSMTest is Test {
 
 
     function setUp() public {
-
         // Deploy new SSM contract
         SSM = new stkSWIV(BAL, Vault, LPT, poolID);
 
@@ -229,6 +228,18 @@ contract SSMTest is Test {
         uint256 amount = startingBalance / 2;
         uint256 previousLPTBalance = LPT.balanceOf(address(SSM));
         SSM.depositZap{value: 1 ether}(amount, Constants.userPublicKey);
+        console.log("LPT Balance: ", LPT.balanceOf(address(SSM)));
+        assertGt(LPT.balanceOf(address(SSM)), previousLPTBalance);
+        assertEq(BAL.balanceOf(address(SSM)), 0);
+        assertEq(BAL.balanceOf(address(WETH)), 0);
+    }
+
+    function testMintZap() public {
+        vm.startPrank(Constants.userPublicKey);
+        uint256 amount = startingBalance*1e18 / 2;
+        uint256 previousLPTBalance = LPT.balanceOf(address(SSM));
+        SSM.mintZap{value: 1 ether}(amount, Constants.userPublicKey); 
+        console.log("LPT Balance: ", LPT.balanceOf(address(SSM)));
         assertGt(LPT.balanceOf(address(SSM)), previousLPTBalance);
         assertEq(BAL.balanceOf(address(SSM)), 0);
         assertEq(BAL.balanceOf(address(WETH)), 0);

--- a/test/Contract.t.sol
+++ b/test/Contract.t.sol
@@ -236,12 +236,20 @@ contract SSMTest is Test {
 
     function testMintZap() public {
         vm.startPrank(Constants.userPublicKey);
-        uint256 amount = startingBalance*1e18 / 2;
+        uint256 amount = 597377559108214882330512;
         uint256 previousLPTBalance = LPT.balanceOf(address(SSM));
         SSM.mintZap{value: 1 ether}(amount, Constants.userPublicKey); 
         console.log("LPT Balance: ", LPT.balanceOf(address(SSM)));
         assertGt(LPT.balanceOf(address(SSM)), previousLPTBalance);
         assertEq(BAL.balanceOf(address(SSM)), 0);
         assertEq(BAL.balanceOf(address(WETH)), 0);
+    }
+
+    function testMintZapTooLittleShares() public {
+        vm.startPrank(Constants.userPublicKey);
+        uint256 amount = 897377559108214882330512;
+        uint256 previousLPTBalance = LPT.balanceOf(address(SSM));
+        vm.expectRevert();
+        SSM.mintZap{value: 1 ether}(amount, Constants.userPublicKey); 
     }
 }


### PR DESCRIPTION
Big PR that covers:
- All zap methods and tests: 
    - mintZap
    - redeemZap
    - depositZap
    - withdrawZap
- Transitioned all cooldown references to `shares`
- Added 2nd return values to all zap methods -- The first aligns with the EIP ("sharesBurnt", "sharesMinted", "assetsDeposited", "assetsWithdrawn" while the 2nd refers to alternate necessary returns of similar sharesToMint values as well as BPT amounts depending on the method

I expect further changes to come with internal word choices to clarify the contract, as well as additional optimization over time and perhaps a batch method added to the contract just because