### PR TITLE
Slippage checks

### DIFF
--- a/src/Interfaces/IQuery.sol
+++ b/src/Interfaces/IQuery.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import "./IVault.sol";
+
+
+interface IQuery {
+
+    function queryJoin(
+            bytes32 poolId,
+            address sender,
+            address recipient,
+            IVault.JoinPoolRequest memory request) external returns (uint256 bptOut, uint256[] memory amountsIn);
+
+    function queryExit(
+        bytes32 poolId,
+        address sender,
+        address recipient,
+        IVault.ExitPoolRequest memory request) external returns (uint256 bptIn, uint256[] memory amountsOut);
+}

--- a/src/stkSWIV.sol
+++ b/src/stkSWIV.sol
@@ -6,6 +6,7 @@ import './Utils/SafeTransferLib.sol';
 import './Utils/FixedPointMathLib.sol';
 import './Interfaces/IVault.sol';
 import './Interfaces/IWETH.sol';
+import './Interfaces/IQuery.sol';
 
 contract stkSWIV is ERC20 {
     using FixedPointMathLib for uint256;
@@ -18,6 +19,9 @@ contract stkSWIV is ERC20 {
     ERC20 immutable public balancerLPT;
     // The Static Balancer Vault
     IVault immutable public balancerVault;
+    // The Static Balancer Query Helper
+    IQuery immutable public balancerQuery;
+
     // The Balancer Pool ID
     bytes32 public balancerPoolID;
     // The withdrawal cooldown length
@@ -26,10 +30,12 @@ contract stkSWIV is ERC20 {
     uint256 public withdrawalWindow = 1 weeks;
     // Mapping of user address -> unix timestamp for cooldown
     mapping (address => uint256) public cooldownTime;
-    // Mapping of user address -> amount of balancerLPT assets to be withdrawn
+    // Mapping of user address -> amount of stkSWIV shares to be withdrawn
     mapping (address => uint256) public cooldownAmount;
     // Determines whether the contract is paused or not
     bool public paused;
+    // The most recently withdrawn BPT timestamp in unix (only when paying out insurance)
+    uint256 public lastWithdrawnBPT;
     // The WETH address
     IWETH immutable public WETH = IWETH(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
 
@@ -47,9 +53,10 @@ contract stkSWIV is ERC20 {
 
     constructor (ERC20 s, IVault v, ERC20 b, bytes32 p) ERC20("Staked SWIV/ETH", "stkSWIV", s.decimals() + 18) {
         SWIV = s;
-        balancerVault = v;
+        balancerVault = IVault(v);
         balancerLPT = b;
         balancerPoolID = p;
+        balancerQuery = IQuery(0xE39B5e3B6D74016b2F6A9673D7d7493B6DF549d5);
         admin = msg.sender;
         SafeTransferLib.approve(SWIV, address(balancerVault), type(uint256).max);
         SafeTransferLib.approve(ERC20(address(WETH)), address(balancerVault), type(uint256).max);
@@ -109,6 +116,31 @@ contract stkSWIV is ERC20 {
         return (convertToShares(assets));
     }
 
+    // Preview the amount of stkSWIV received from zapping and depositing `swivelAmount` of SWIV alongside a proportional amount of ETH
+    // @param: swivelAmount - amount of SWIV tokens
+    // @returns: shares the amount of stkSWIV shares received
+    function previewDepositZap(uint256 swivelAmount) public returns (uint256 shares) {
+        // Instantiate balancer request struct using SWIV and ETH alongside the amounts sent
+        IAsset[] memory assetData = new IAsset[](2);
+        assetData[0] = IAsset(address(SWIV));
+        assetData[1] = IAsset(address(WETH));
+
+        uint256[] memory amountData = new uint256[](2);
+        amountData[0] = swivelAmount;
+        amountData[1] = type(uint256).max;
+
+        IVault.JoinPoolRequest memory requestData = IVault.JoinPoolRequest({
+                    assets: assetData,
+                    maxAmountsIn: amountData,
+                    userData: abi.encode(1, amountData, 0),
+                    fromInternalBalance: false
+                });
+        // Query the pool join to get the bpt out
+        (uint256 bptOut, uint256[] memory amountsIn) = balancerQuery.queryJoin(balancerPoolID, msg.sender, address(this), requestData);
+
+        return (convertToShares(bptOut));
+    }
+
     // Preview of the amount of stkSWIV required to withdraw `assets` of balancerLPT
     // @param: assets - amount of balancerLPT tokens
     // @returns: shares the amount of stkSWIV shares required
@@ -147,8 +179,7 @@ contract stkSWIV is ERC20 {
     // Queues `amount` of balancerLPT assets to be withdrawn after the cooldown period
     // @param: amount - amount of balancerLPT assets to be withdrawn
     // @returns: the total amount of balancerLPT assets to be withdrawn
-    function cooldown(uint256 assets) public returns (uint256) {
-        uint256 shares = convertToShares(assets);
+    function cooldown(uint256 shares) public returns (uint256) {
         // Require the total amount to be < balanceOf
         if (cooldownAmount[msg.sender] + shares > balanceOf[msg.sender]) {
             revert Exception(3, cooldownAmount[msg.sender] + shares, balanceOf[msg.sender], msg.sender, address(0));
@@ -158,7 +189,7 @@ contract stkSWIV is ERC20 {
         // Add the amount;
         cooldownAmount[msg.sender] = cooldownAmount[msg.sender] + shares;
 
-        return(convertToAssets(cooldownAmount[msg.sender]) + assets);
+        return(cooldownAmount[msg.sender]);
     }
 
     // Mints `shares` to `receiver` and transfers `assets` of balancerLPT tokens from `msg.sender`
@@ -287,21 +318,9 @@ contract stkSWIV is ERC20 {
     // Then joins the balancer pool with the SWIV and ETH before minting `shares` to `receiver`
     // @param: shares - amount of stkSWIV shares to mint
     // @param: receiver - address of the receiver
-<<<<<<< Updated upstream
-    // @returns: the amount of SWIV tokens deposited
-    function mintZap(uint256 shares, address receiver) public payable returns (uint256) {
-        // Convert shares to assets
-        uint256 assets = previewMint(shares);
-        // Transfer assets of SWIV tokens from sender to this contract
-        SafeTransferLib.transferFrom(SWIV, msg.sender, address(this), assets);
-        // Instantiate balancer request struct using SWIV and ETH alongside the amounts sent
-        IAsset[] memory assetData;
-        assetData[0] = IAsset(address(SWIV));
-        assetData[1] = IAsset(address(0));
-=======
-    // @returns: assets the amount of SWIV tokens deposited
+    // @returns: assets the amount of balancerBPT tokens deposited
     // @returns: sharesToMint the actual amount of shares minted
-    function mintZap(uint256 shares, address receiver) public payable returns (uint256 assets, uint256 sharesToMint, uint256 bptOut) {
+    function mintZap(uint256 shares, address receiver) public payable returns (uint256 assets, uint256 sharesToMint, uint256[] memory balancesSpent) {
         // Get token info from vault
         (,uint256[] memory balances,) = balancerVault.getPoolTokens(balancerPoolID);
         // Calculate SWIV transfer amount from msg.value (expecting at least enough msg.value and SWIV available to cover `shares` minted)
@@ -310,57 +329,30 @@ contract stkSWIV is ERC20 {
         IAsset[] memory assetData = new IAsset[](2);
         assetData[0] = IAsset(address(SWIV));
         assetData[1] = IAsset(address(WETH));
->>>>>>> Stashed changes
 
         uint256[] memory amountData;
         amountData[0] = assets;
         amountData[1] = msg.value;
 
         IVault.JoinPoolRequest memory requestData = IVault.JoinPoolRequest({
-<<<<<<< Updated upstream
-            assets: assetData,
-            maxAmountsIn: amountData,
-            userData: new bytes(0),
-            fromInternalBalance: false
-        });
-=======
                     assets: assetData,
                     maxAmountsIn: amountData,
                     userData: abi.encode(1, amountData, 0),
                     fromInternalBalance: false
                 });
         // Query the pool join to get the bpt out (assets)
-        (uint256 bptOut, uint256[] memory amountsIn) = balancerQuery.queryJoin(balancerPoolID, msg.sender, address(this), requestData);
+        (uint256 bptOut, uint256[] memory balancesSpent) = balancerQuery.queryJoin(balancerPoolID, msg.sender, address(this), requestData);
         // Calculate expected shares to mint before transfering funds 
         sharesToMint = convertToShares(bptOut);
         // Wrap msg.value into WETH
         WETH.deposit{value: msg.value}();
         // Transfer assets of SWIV tokens from sender to this contract
-        SafeTransferLib.transferFrom(SWIV, msg.sender, address(this), amountsIn[0]); 
+        SafeTransferLib.transferFrom(SWIV, msg.sender, address(this), balancesSpent[0]); 
         // Encode new userData with queried amountsIn and bptOut
-        requestData.userData = abi.encode(1, amountsIn, bptOut);
->>>>>>> Stashed changes
+        requestData.userData = abi.encode(1, balancesSpent, bptOut);
         // Join the balancer pool using the request struct
         IVault(balancerVault).joinPool(balancerPoolID, address(this), address(this), requestData);
         // Mint shares to receiver
-<<<<<<< Updated upstream
-        _mint(receiver, shares);
-        // If there is any leftover SWIV, transfer it to the msg.sender
-        uint256 swivBalance = SWIV.balanceOf(address(this));
-        if (swivBalance > 0) {
-            // Transfer the SWIV to the receiver
-            SafeTransferLib.transfer(SWIV, msg.sender, swivBalance);
-        }
-        // If there is any leftover ETH, transfer it to the msg.sender
-        if (address(this).balance > 0) {
-            // Transfer the ETH to the receiver
-            payable(msg.sender).transfer(address(this).balance);
-        }
-        // Emit deposit event
-        emit Deposit(msg.sender, receiver, assets, shares);
-
-        return (assets);
-=======
         _mint(receiver, sharesToMint);
         {
             // If there is any leftover SWIV, transfer it to the msg.sender
@@ -380,8 +372,7 @@ contract stkSWIV is ERC20 {
         // Emit deposit event
         emit Deposit(msg.sender, receiver, bptOut, sharesToMint);
 
-        return (bptOut, sharesToMint, bptOut);
->>>>>>> Stashed changes
+        return (bptOut, sharesToMint, balancesSpent);
     }
 
     // Exits the balancer pool and transfers `assets` of SWIV tokens and the current balance of ETH to `receiver`
@@ -390,14 +381,9 @@ contract stkSWIV is ERC20 {
     // @param: shares - maximum amount of stkSWIV shares to redeem
     // @param: receiver - address of the receiver
     // @param: owner - address of the owner
-<<<<<<< Updated upstream
-    // @returns: the amount of SWIV tokens withdrawn
-    function redeemZap(uint256 shares, address payable receiver, address owner) Unpaused()  public returns (uint256) {
-=======
     // @returns: assets the amount of bpt withdrawn
     // @returns: sharesBurnt the amount of stkSWIV shares burnt
-    function redeemZap(uint256 shares, address payable receiver, address owner) Unpaused()  public returns (uint256 assets, uint256 sharesBurnt, uint256 bptIn) {
->>>>>>> Stashed changes
+    function redeemZap(uint256 shares, address payable receiver, address owner) Unpaused()  public returns (uint256 assets, uint256 sharesBurnt, uint256[] memory balancesReturned) {
         // Convert shares to assets
         uint256 assets = previewRedeem(shares);
         // Get the cooldown time
@@ -436,10 +422,8 @@ contract stkSWIV is ERC20 {
             userData: new bytes(0),
             toInternalBalance: false
         });
-<<<<<<< Updated upstream
-=======
         // Query the pool exit to get the amounts out
-        (uint256 bptIn,) = balancerQuery.queryExit(balancerPoolID, address(this), address(this), requestData);
+        (uint256 bptIn, uint256[] memory balancesReturned) = balancerQuery.queryExit(balancerPoolID, address(this), address(this), requestData);
         // Require the amount of bptIn to be greater than the minimum (slippage check)
         if (bptIn != assets) {
             require(bptIn >= assets, "shares redeemed > maximum due to slippage");
@@ -447,7 +431,6 @@ contract stkSWIV is ERC20 {
         }
         // Encode new userData with queried amountsOut and bptIn
         requestData.userData = abi.encode(1, bptIn);
->>>>>>> Stashed changes
         // Exit the balancer pool using the request struct
         IVault(balancerVault).exitPool(balancerPoolID, payable(address(this)), payable(address(this)), requestData);
         // Transfer the SWIV tokens to the receiver
@@ -461,42 +444,23 @@ contract stkSWIV is ERC20 {
         // Reset the cooldown amount
         cooldownAmount[msg.sender] = 0;
         // Emit withdraw event
-        emit Withdraw(msg.sender, receiver, owner, assets, shares);
+        emit Withdraw(msg.sender, receiver, owner, bptIn, shares);
 
-<<<<<<< Updated upstream
-        return (assets);
-=======
-        return (bptIn, shares, bptIn);
->>>>>>> Stashed changes
+        return (bptIn, shares, balancesReturned);
     }
 
     // Transfers `assets` of SWIV tokens from `msg.sender` while receiving `msg.value` of ETH
     // Then joins the balancer pool with the SWIV and ETH before minting `shares` to `receiver`
-<<<<<<< Updated upstream
-    // @param: assets - amount of SWIV tokens to deposit
-=======
-    // @notice: I dont believe there is a limitation to slippage on this method.
     // @param: assets - maximum amount of SWIV tokens to deposit
->>>>>>> Stashed changes
     // @param: receiver - address of the receiver
     // @param: minimumBPT - minimum amount of balancerLPT tokens to mint
     // @returns: the amount of stkSWIV shares minted
-<<<<<<< Updated upstream
-    function depositZap(uint256 assets, address receiver) public payable returns (uint256) {
-
-        // Convert assets to shares
-        uint256 shares = previewDeposit(assets);
-=======
     // @returns: the amount of swiv actually deposited
-    function depositZap(uint256 assets, address receiver, uint256 minimumBPT) public payable returns (uint256 sharesMinted, uint256 bptIn, uint256[2] memory balancesSpent) {
->>>>>>> Stashed changes
+    function depositZap(uint256 assets, address receiver, uint256 minimumBPT) public payable returns (uint256 sharesMinted, uint256 bptIn, uint256[] memory balancesSpent) {
         // Transfer assets of SWIV tokens from sender to this contract
         SafeTransferLib.transferFrom(SWIV, msg.sender, address(this), assets);    
         // Wrap msg.value into WETH
         WETH.deposit{value: msg.value}();
-
-        emit TestException(WETH.balanceOf((address(this))), receiver, "test");
-
         // Instantiate balancer request struct using SWIV and ETH alongside the amounts sent
         IAsset[] memory assetData = new IAsset[](2);
         assetData[0] = IAsset(address(SWIV));
@@ -507,47 +471,38 @@ contract stkSWIV is ERC20 {
         amountData[1] = msg.value;
 
         IVault.JoinPoolRequest memory requestData = IVault.JoinPoolRequest({
-<<<<<<< Updated upstream
-            assets: assetData,
-            maxAmountsIn: amountData,
-            userData: new bytes(0),
-            fromInternalBalance: false
-        });
-        
-=======
                     assets: assetData,
                     maxAmountsIn: amountData,
                     userData: abi.encode(1, amountData, 0),
                     fromInternalBalance: false
                 });
         // Query the pool join to get the bpt out
-        (uint256 bptOut, uint256[] memory amountsIn) = balancerQuery.queryJoin(balancerPoolID, msg.sender, address(this), requestData);
+        (uint256 bptOut, uint256[] memory balancesSpent) = balancerQuery.queryJoin(balancerPoolID, msg.sender, address(this), requestData);
         // Require the amount of bptOut to be greater than the minimum (slippage check)
         require(bptOut > minimumBPT, "bpt recieved < minimum");
         // mint shares to receiver
         sharesMinted = convertToShares(bptOut);
         // Encode new userData with queried amountsIn and bptOut
-        requestData.userData = abi.encode(1, amountsIn, bptOut);
->>>>>>> Stashed changes
+        requestData.userData = abi.encode(1, balancesSpent, bptOut);
         // Join the balancer pool using the request struct
         IVault(balancerVault).joinPool(balancerPoolID, address(this), address(this), requestData);
-        // // Mint shares to receiver
-        // _mint(receiver, shares);
-        // // If there is any leftover SWIV, transfer it to the msg.sender
-        // uint256 swivBalance = SWIV.balanceOf(address(this));
-        // if (swivBalance > 0) {
-        //     // Transfer the SWIV to the receiver
-        //     SafeTransferLib.transfer(SWIV, msg.sender, swivBalance);
-        // }
-        // // If there is any leftover ETH, transfer it to the msg.sender
-        // if (address(this).balance > 0) {
-        //     // Transfer the ETH to the receiver
-        //     payable(msg.sender).transfer(address(this).balance);
-        // }
-        // // Emit deposit event
-        // emit Deposit(msg.sender, receiver, assets, shares);
+        // Mint shares to receiver
+        _mint(receiver, sharesMinted);
+        // If there is any leftover SWIV, transfer it to the msg.sender
+        uint256 swivBalance = SWIV.balanceOf(address(this));
+        if (swivBalance > 0) {
+            // Transfer the SWIV to the receiver
+            SafeTransferLib.transfer(SWIV, msg.sender, swivBalance);
+        }
+        // If there is any leftover ETH, transfer it to the msg.sender
+        if (address(this).balance > 0) {
+            // Transfer the ETH to the receiver
+            payable(msg.sender).transfer(address(this).balance);
+        }
+        // Emit deposit event
+        emit Deposit(msg.sender, receiver, assets, sharesMinted);
 
-        // return (shares);
+        return (sharesMinted, bptOut, balancesSpent);
     }
 
     // Exits the balancer pool and transfers `assets` of SWIV tokens and the current balance of ETH to `receiver`
@@ -557,37 +512,15 @@ contract stkSWIV is ERC20 {
     // @param: receiver - address of the receiver
     // @param: owner - address of the owner
     // @returns: the amount of stkSWIV shares burnt
-<<<<<<< Updated upstream
-    function withdrawZap(uint256 assets, address payable receiver, address owner) Unpaused() public returns (uint256) {
-        // Convert assets to shares
-        uint256 shares = previewWithdraw(assets);
-=======
-    function withdrawZap(uint256 assets, uint256 ethAssets, address payable receiver, address owner, uint256 maximumBPT) Unpaused() public returns (uint256 sharesRedeemed, uint256 bptOut, uint256[2] memory balancesReturned) {
->>>>>>> Stashed changes
-        // Get the cooldown time
-        uint256 cTime = cooldownTime[msg.sender];
-        // If the sender is not the owner check allowances
-        if (msg.sender != owner) {
-            uint256 allowed = allowance[owner][msg.sender];
-            // If the allowance is not max, subtract the shares from the allowance, reverts on underflow if not enough allowance
-            if (allowed != type(uint256).max) allowance[owner][msg.sender] = allowed - shares;
+    function withdrawZap(uint256 assets, uint256 ethAssets, address payable receiver, address owner, uint256 maximumBPT) Unpaused() public returns (uint256 sharesRedeemed, uint256 bptOut, uint256[] memory balancesReturned) {
+        {
+            // Get the cooldown time
+            uint256 cTime = cooldownTime[msg.sender];
+            // If the cooldown time is in the future or 0, revert
+            if (cTime > block.timestamp || cTime == 0 || cTime + withdrawalWindow < block.timestamp) {
+                revert Exception(0, cTime, block.timestamp, address(0), address(0));
+            }
         }
-        // If the cooldown time is in the future or 0, revert
-        if (cTime > block.timestamp || cTime == 0 || cTime + withdrawalWindow < block.timestamp) {
-            revert Exception(0, cTime, block.timestamp, address(0), address(0));
-        }
-<<<<<<< Updated upstream
-        // If the redeemed shares is greater than the cooldown amount, revert
-        uint256 cAmount = cooldownAmount[msg.sender];
-        if (shares > cAmount) {
-            revert Exception(1, cAmount, shares, address(0), address(0));
-        }
-        // If the shares are greater than the balance of the owner, revert
-        if (shares > this.balanceOf(owner)) {
-            revert Exception(2, shares, this.balanceOf(owner), address(0), address(0));
-        }
-=======
->>>>>>> Stashed changes
         // Instantiate balancer request struct using SWIV and ETH alongside the asset amount and 0 ETH
         IAsset[] memory assetData;
         assetData[0] = IAsset(address(SWIV));
@@ -595,7 +528,7 @@ contract stkSWIV is ERC20 {
 
         uint256[] memory amountData;
         amountData[0] = assets;
-        amountData[1] = 0;
+        amountData[1] = ethAssets;
 
         IVault.ExitPoolRequest memory requestData = IVault.ExitPoolRequest({
             assets: assetData,
@@ -603,16 +536,14 @@ contract stkSWIV is ERC20 {
             userData: new bytes(0),
             toInternalBalance: false
         });
-<<<<<<< Updated upstream
-=======
         // Query the pool exit to get the amounts out
-        (uint256 bptOut, uint256[] memory amountsOut) = balancerQuery.queryExit(balancerPoolID, address(this), address(this), requestData);
+        (uint256 bptOut, uint256[] memory balancesReturned) = balancerQuery.queryExit(balancerPoolID, address(this), address(this), requestData);
         // Require the amount of bptOut to be greater than the minimum (slippage check)
         require(bptOut <= maximumBPT, "BPT required is > the maximum, due to slippage");
+        // Convert To shares
         sharesRedeemed = convertToShares(bptOut);
         // Encode new userData with queried amountsOut and bptIn
-        requestData.userData = abi.encode(2, amountsOut, bptOut);
-        // Convert bptIn to shares
+        requestData.userData = abi.encode(2, balancesReturned, bptOut);
         // This method is unique in that we cannot check against cAmounts before calculating shares
         // If the redeemed shares is greater than the cooldown amount, revert
         {
@@ -621,32 +552,46 @@ contract stkSWIV is ERC20 {
                 revert Exception(1, cAmount, sharesRedeemed, address(0), address(0));
             }
         }
-        // If the shares are greater than the balance of the owner, revert
-        if (sharesRedeemed > this.balanceOf(owner)) {
-            revert Exception(2, sharesRedeemed, this.balanceOf(owner), address(0), address(0));
+        {
+            // If the shares are greater than the balance of the owner, revert
+            if (sharesRedeemed > this.balanceOf(owner)) {
+                revert Exception(2, sharesRedeemed, this.balanceOf(owner), address(0), address(0));
+            }
         }
-        if (msg.sender != owner) {
-            uint256 allowed = allowance[owner][msg.sender];
-            // If the allowance is not max, subtract the shares from the allowance, reverts on underflow if not enough allowance
-            if (allowed != type(uint256).max) allowance[owner][msg.sender] = allowed - sharesRedeemed;
+        {
+            // If the sender is not the owner check allowances
+            if (msg.sender != owner) {
+                uint256 allowed = allowance[owner][msg.sender];
+                // If the allowance is not max, subtract the shares from the allowance, reverts on underflow if not enough allowance
+                if (allowed != type(uint256).max) allowance[owner][msg.sender] = allowed - sharesRedeemed;
+            }
         }
->>>>>>> Stashed changes
+        {
+            if (msg.sender != owner) {
+                uint256 allowed = allowance[owner][msg.sender];
+                // If the allowance is not max, subtract the shares from the allowance, reverts on underflow if not enough allowance
+                if (allowed != type(uint256).max) allowance[owner][msg.sender] = allowed - sharesRedeemed;
+            }
+        }
         // Exit the balancer pool using the request struct
         IVault(balancerVault).exitPool(balancerPoolID, payable(address(this)), payable(address(this)), requestData);
         // Transfer the SWIV tokens to the receiver
         SafeTransferLib.transfer(SWIV, receiver, SWIV.balanceOf(address(this)));
-        // Transfer the ETH to the receiver
-        receiver.transfer(address(this).balance);
+        {
+            // Transfer the ETH to the receiver
+            receiver.transfer(address(this).balance);
+        }
         // Burn the shares
-        _burn(msg.sender, shares);
+        _burn(msg.sender, sharesRedeemed);
         // Reset the cooldown time
         cooldownTime[msg.sender] = 0;
         // Reset the cooldown amount
         cooldownAmount[msg.sender] = 0;
         // Emit withdraw event
-        emit Withdraw(msg.sender, receiver, owner, assets, shares);
-
-        return (shares);
+        {
+        emit Withdraw(msg.sender, receiver, owner, assets, sharesRedeemed);
+        }
+        return (sharesRedeemed, bptOut, balancesReturned);
     }
 
     //////////////////// ADMIN FUNCTIONS ////////////////////

--- a/src/stkSWIV.sol
+++ b/src/stkSWIV.sol
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >= 0.8.4;
-
+import "forge-std/console.sol";
 import './ERC/SolmateERC20.sol';
 import './Utils/SafeTransferLib.sol';
 import './Utils/FixedPointMathLib.sol';
 import './Interfaces/IVault.sol';
+import './Interfaces/IWETH.sol';
 
 contract stkSWIV is ERC20 {
     using FixedPointMathLib for uint256;
@@ -29,6 +30,8 @@ contract stkSWIV is ERC20 {
     mapping (address => uint256) public cooldownAmount;
     // Determines whether the contract is paused or not
     bool public paused;
+    // The WETH address
+    IWETH immutable public WETH = IWETH(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
 
     event Deposit(address indexed caller, address indexed owner, uint256 assets, uint256 shares);
 
@@ -42,13 +45,19 @@ contract stkSWIV is ERC20 {
 
     error Exception(uint8, uint256, uint256, address, address);
 
+    event TestException(uint256, address, string);
+
     constructor (ERC20 s, IVault v, ERC20 b, bytes32 p) ERC20("Staked SWIV/ETH", "stkSWIV", s.decimals() + 18) {
         SWIV = s;
         balancerVault = v;
         balancerLPT = b;
         balancerPoolID = p;
         admin = msg.sender;
-        SafeTransferLib.approve(SWIV, address(balancerLPT), type(uint256).max);
+        SafeTransferLib.approve(SWIV, address(balancerVault), type(uint256).max);
+        SafeTransferLib.approve(ERC20(address(WETH)), address(balancerVault), type(uint256).max);
+    }
+
+    fallback() external payable {
     }
 
     function asset() public view returns (address) {
@@ -396,13 +405,18 @@ contract stkSWIV is ERC20 {
         uint256 shares = previewDeposit(assets);
         // Transfer assets of SWIV tokens from sender to this contract
         SafeTransferLib.transferFrom(SWIV, msg.sender, address(this), assets);    
-        // Instantiate balancer request struct using SWIV and ETH alongside the amounts sent
-        IAsset[] memory assetData;
-        assetData[0] = IAsset(address(SWIV));
-        assetData[1] = IAsset(address(0));
+        // Wrap msg.value into WETH
+        WETH.deposit{value: msg.value}();
 
-        uint256[] memory amountData;
-        amountData[0] = assets;
+        emit TestException(WETH.balanceOf((address(this))), receiver, "test");
+
+        // Instantiate balancer request struct using SWIV and ETH alongside the amounts sent
+        IAsset[] memory assetData = new IAsset[](2);
+        assetData[0] = IAsset(address(SWIV));
+        assetData[1] = IAsset(address(WETH));
+
+        uint256[] memory amountData = new uint256[](2);
+        amountData[0] = 1;
         amountData[1] = msg.value;
 
         IVault.JoinPoolRequest memory requestData = IVault.JoinPoolRequest({
@@ -411,25 +425,26 @@ contract stkSWIV is ERC20 {
             userData: new bytes(0),
             fromInternalBalance: false
         });
+        
         // Join the balancer pool using the request struct
         IVault(balancerVault).joinPool(balancerPoolID, address(this), address(this), requestData);
-        // Mint shares to receiver
-        _mint(receiver, shares);
-        // If there is any leftover SWIV, transfer it to the msg.sender
-        uint256 swivBalance = SWIV.balanceOf(address(this));
-        if (swivBalance > 0) {
-            // Transfer the SWIV to the receiver
-            SafeTransferLib.transfer(SWIV, msg.sender, swivBalance);
-        }
-        // If there is any leftover ETH, transfer it to the msg.sender
-        if (address(this).balance > 0) {
-            // Transfer the ETH to the receiver
-            payable(msg.sender).transfer(address(this).balance);
-        }
-        // Emit deposit event
-        emit Deposit(msg.sender, receiver, assets, shares);
+        // // Mint shares to receiver
+        // _mint(receiver, shares);
+        // // If there is any leftover SWIV, transfer it to the msg.sender
+        // uint256 swivBalance = SWIV.balanceOf(address(this));
+        // if (swivBalance > 0) {
+        //     // Transfer the SWIV to the receiver
+        //     SafeTransferLib.transfer(SWIV, msg.sender, swivBalance);
+        // }
+        // // If there is any leftover ETH, transfer it to the msg.sender
+        // if (address(this).balance > 0) {
+        //     // Transfer the ETH to the receiver
+        //     payable(msg.sender).transfer(address(this).balance);
+        // }
+        // // Emit deposit event
+        // emit Deposit(msg.sender, receiver, assets, shares);
 
-        return (shares);
+        // return (shares);
     }
 
     // Exits the balancer pool and transfers `assets` of SWIV tokens and the current balance of ETH to `receiver`

--- a/test/Contract.t.sol
+++ b/test/Contract.t.sol
@@ -9,7 +9,7 @@ import {stkSWIV} from 'src/stkSWIV.sol';
 import {ERC20} from 'src/ERC/SolmateERC20.sol';
 import {IVault} from 'src/Interfaces/IVault.sol';
 import {IERC20} from 'src/Interfaces/IERC20.sol';
-
+import {IWETH} from 'src/Interfaces/IWETH.sol';
 import {Constants} from 'test/Constants.sol';
 
 contract SSMTest is Test {
@@ -19,6 +19,7 @@ contract SSMTest is Test {
     ERC20 BAL = ERC20(0xba100000625a3754423978a60c9317c58a424e3D);
     IVault Vault = IVault(0xBA12222222228d8Ba445958a75a0704d566BF2C8);
     ERC20 LPT = ERC20(0x5c6Ee304399DBdB9C8Ef030aB642B10820DB8F56);
+    IWETH WETH = IWETH(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
     bytes32 poolID = 0x5c6ee304399dbdb9c8ef030ab642b10820db8f56000200000000000000000014;
     uint256 startingBalance = 1923.29 * 2 * 1e18;
 
@@ -223,11 +224,6 @@ function getMappingValue(address targetContract, uint256 mapSlot, address key) p
     function testDepositZap() public {
         vm.startPrank(Constants.userPublicKey);
         uint256 amount = startingBalance / 2;
-<<<<<<< Updated upstream
-        SSM.depositZap{value: 1 ether}(amount, Constants.userPublicKey);
-        // assertEq(LPT.balanceOf(Constants.userPublicKey), amount);
-        // assertEq(SSM.balanceOf(Constants.userPublicKey), amount*1e18);
-=======
         uint256 previousLPTBalance = LPT.balanceOf(address(SSM));
         SSM.depositZap{value: 1 ether}(amount, Constants.userPublicKey, 0);
         console.log("LPT Balance: ", LPT.balanceOf(address(SSM)));
@@ -259,7 +255,7 @@ function getMappingValue(address targetContract, uint256 mapSlot, address key) p
     function testRedeemZap() public {
         vm.startPrank(Constants.userPublicKey);
         uint256 amount = 697377559108214882330512;
-        (uint256 minBPT,uint256 sharesMinted) = SSM.mintZap{value: 1 ether}(amount, Constants.userPublicKey);
+        (uint256 minBPT,uint256 sharesMinted,) = SSM.mintZap{value: 1 ether}(amount, Constants.userPublicKey);
         SSM.cooldown(sharesMinted);
         vm.warp(block.timestamp + SSM.cooldownLength());
         SSM.redeemZap(sharesMinted, payable(Constants.userPublicKey), Constants.userPublicKey);
@@ -269,7 +265,7 @@ function getMappingValue(address targetContract, uint256 mapSlot, address key) p
         vm.startPrank(Constants.userPublicKey);
         uint256 amount = startingBalance / 2;
         uint256 ethAmount = 1 ether;
-        (uint256 sharesMinted, ,uint256[2] memory balancesSpent) = SSM.depositZap{value: ethAmount}(amount, Constants.userPublicKey, 0);
+        (uint256 sharesMinted,,uint256[2] memory balancesSpent) = SSM.depositZap{value: ethAmount}(amount, Constants.userPublicKey, 0);
         uint256 swivDeposited = balancesSpent[0];
         console.log("Shares Minted: ", sharesMinted);
         console.log("Swiv Deposited: ", swivDeposited);
@@ -279,6 +275,5 @@ function getMappingValue(address targetContract, uint256 mapSlot, address key) p
         uint256 ethWithdrawn = ethAmount - (ethAmount*5/10000);
         (uint256 sharesBurnt, ,uint256[2] memory balancesReturned ) = SSM.withdrawZap(swivWithdrawn, ethWithdrawn, payable(Constants.userPublicKey), Constants.userPublicKey, type(uint256).max); 
         assertApproxEqRel(SSM.convertToShares(853211022431743032540), SSM.convertToShares(853282338599770425535),0.005e18);
->>>>>>> Stashed changes
     }
 }

--- a/test/Contract.t.sol
+++ b/test/Contract.t.sol
@@ -223,8 +223,62 @@ function getMappingValue(address targetContract, uint256 mapSlot, address key) p
     function testDepositZap() public {
         vm.startPrank(Constants.userPublicKey);
         uint256 amount = startingBalance / 2;
+<<<<<<< Updated upstream
         SSM.depositZap{value: 1 ether}(amount, Constants.userPublicKey);
         // assertEq(LPT.balanceOf(Constants.userPublicKey), amount);
         // assertEq(SSM.balanceOf(Constants.userPublicKey), amount*1e18);
+=======
+        uint256 previousLPTBalance = LPT.balanceOf(address(SSM));
+        SSM.depositZap{value: 1 ether}(amount, Constants.userPublicKey, 0);
+        console.log("LPT Balance: ", LPT.balanceOf(address(SSM)));
+        assertGt(LPT.balanceOf(address(SSM)), previousLPTBalance);
+        assertEq(BAL.balanceOf(address(SSM)), 0);
+        assertEq(BAL.balanceOf(address(WETH)), 0);
+    }
+
+    function testMintZap() public {
+        vm.startPrank(Constants.userPublicKey);
+        uint256 amount = 833211022431743032540000000000000000000;
+        uint256 previousLPTBalance = LPT.balanceOf(address(SSM));
+        SSM.mintZap{value: 1 ether}(amount, Constants.userPublicKey);
+        assertGe(SSM.balanceOf(address(Constants.userPublicKey)), amount);
+        console.log("LPT Balance: ", LPT.balanceOf(address(SSM)));
+        assertGt(LPT.balanceOf(address(SSM)), previousLPTBalance);
+        assertEq(BAL.balanceOf(address(SSM)), 0);
+        assertEq(BAL.balanceOf(address(WETH)), 0);
+    }
+
+    function testMintZapTooLittleShares() public {
+        vm.startPrank(Constants.userPublicKey);
+        uint256 amount = 853211022431743032540000000000000000001;
+        uint256 previousLPTBalance = LPT.balanceOf(address(SSM));
+        vm.expectRevert();
+        SSM.mintZap{value: 1 ether}(amount, Constants.userPublicKey); 
+    }
+
+    function testRedeemZap() public {
+        vm.startPrank(Constants.userPublicKey);
+        uint256 amount = 697377559108214882330512;
+        (uint256 minBPT,uint256 sharesMinted) = SSM.mintZap{value: 1 ether}(amount, Constants.userPublicKey);
+        SSM.cooldown(sharesMinted);
+        vm.warp(block.timestamp + SSM.cooldownLength());
+        SSM.redeemZap(sharesMinted, payable(Constants.userPublicKey), Constants.userPublicKey);
+    }
+
+    function testWithdrawZap() public {
+        vm.startPrank(Constants.userPublicKey);
+        uint256 amount = startingBalance / 2;
+        uint256 ethAmount = 1 ether;
+        (uint256 sharesMinted, ,uint256[2] memory balancesSpent) = SSM.depositZap{value: ethAmount}(amount, Constants.userPublicKey, 0);
+        uint256 swivDeposited = balancesSpent[0];
+        console.log("Shares Minted: ", sharesMinted);
+        console.log("Swiv Deposited: ", swivDeposited);
+        SSM.cooldown(sharesMinted);
+        vm.warp(block.timestamp + SSM.cooldownLength());
+        uint256 swivWithdrawn = swivDeposited - (swivDeposited*5/10000);
+        uint256 ethWithdrawn = ethAmount - (ethAmount*5/10000);
+        (uint256 sharesBurnt, ,uint256[2] memory balancesReturned ) = SSM.withdrawZap(swivWithdrawn, ethWithdrawn, payable(Constants.userPublicKey), Constants.userPublicKey, type(uint256).max); 
+        assertApproxEqRel(SSM.convertToShares(853211022431743032540), SSM.convertToShares(853282338599770425535),0.005e18);
+>>>>>>> Stashed changes
     }
 }

--- a/test/Contract.t.sol
+++ b/test/Contract.t.sol
@@ -73,7 +73,7 @@ function getMappingValue(address targetContract, uint256 mapSlot, address key) p
         uint256 amount = startingBalance / 2;
         SSM.deposit(amount, Constants.userPublicKey);
 
-        SSM.cooldown(amount);
+        SSM.cooldown(amount*1e18);
         assertEq(SSM.cooldownTime(Constants.userPublicKey), block.timestamp + SSM.cooldownLength());
         assertEq(SSM.cooldownAmount(Constants.userPublicKey), amount*1e18);
     }
@@ -82,7 +82,7 @@ function getMappingValue(address targetContract, uint256 mapSlot, address key) p
         vm.startPrank(Constants.userPublicKey);
         uint256 amount = startingBalance / 2;
         SSM.deposit(amount, Constants.userPublicKey);
-        SSM.cooldown(amount);
+        SSM.cooldown(amount*1e18);
         vm.warp(block.timestamp+ SSM.cooldownLength());
         SSM.withdraw(amount, Constants.userPublicKey, Constants.userPublicKey);
         assertEq(LPT.balanceOf(Constants.userPublicKey), startingBalance);
@@ -93,7 +93,7 @@ function getMappingValue(address targetContract, uint256 mapSlot, address key) p
         vm.startPrank(Constants.userPublicKey);
         uint256 amount = startingBalance / 2;
         SSM.deposit(amount, Constants.userPublicKey);
-        SSM.cooldown(amount);
+        SSM.cooldown(amount*1e18);
         vm.warp(block.timestamp+ SSM.cooldownLength());
         SSM.redeem(amount*1e18, Constants.userPublicKey, Constants.userPublicKey);
         assertEq(LPT.balanceOf(Constants.userPublicKey), startingBalance);
@@ -104,7 +104,7 @@ function getMappingValue(address targetContract, uint256 mapSlot, address key) p
         vm.startPrank(Constants.userPublicKey);
         uint256 amount = startingBalance / 2;
         SSM.deposit(amount, Constants.userPublicKey);
-        SSM.cooldown(amount);
+        SSM.cooldown(amount*1e18);
         LPT.transfer(address(SSM), amount);
         vm.warp(block.timestamp+ SSM.cooldownLength());
         SSM.redeem(amount*1e18, Constants.userPublicKey, Constants.userPublicKey);
@@ -116,7 +116,7 @@ function getMappingValue(address targetContract, uint256 mapSlot, address key) p
         vm.startPrank(Constants.userPublicKey);
         uint256 amount = startingBalance / 2;
         SSM.deposit(amount, Constants.userPublicKey);
-        SSM.cooldown(amount);
+        SSM.cooldown(amount*1e18);
         LPT.transfer(address(SSM), amount);
         vm.warp(block.timestamp+ SSM.cooldownLength());
         SSM.redeem(amount*1e18, Constants.userPublicKey, Constants.userPublicKey);
@@ -128,7 +128,7 @@ function getMappingValue(address targetContract, uint256 mapSlot, address key) p
         vm.startPrank(Constants.userPublicKey);
         uint256 amount = startingBalance / 2;
         SSM.deposit(amount, Constants.userPublicKey);
-        SSM.cooldown(amount/2);
+        SSM.cooldown(amount*1e18/2);
         vm.warp(block.timestamp+ SSM.cooldownLength());
         SSM.withdraw(amount/2, Constants.userPublicKey, Constants.userPublicKey);
         SSM.deposit(amount + amount/2, Constants.userPublicKey);
@@ -140,7 +140,7 @@ function getMappingValue(address targetContract, uint256 mapSlot, address key) p
         vm.startPrank(Constants.userPublicKey);
         uint256 amount = (startingBalance*1e18) / 2;
         SSM.mint(amount, Constants.userPublicKey);
-        SSM.cooldown(amount/1e18/2);
+        SSM.cooldown(amount/2);
         vm.warp(block.timestamp+ SSM.cooldownLength());
         SSM.redeem(amount/2, Constants.userPublicKey, Constants.userPublicKey);
         SSM.mint(amount + amount/2, Constants.userPublicKey);
@@ -152,7 +152,7 @@ function getMappingValue(address targetContract, uint256 mapSlot, address key) p
         vm.startPrank(Constants.userPublicKey);
         uint256 amount = startingBalance / 2;
         SSM.deposit(amount, Constants.userPublicKey);
-        SSM.cooldown(amount);
+        SSM.cooldown(amount*1e18);
         vm.warp(block.timestamp+ SSM.cooldownLength());
         vm.stopPrank();
         SSM.pause(true);
@@ -165,7 +165,7 @@ function getMappingValue(address targetContract, uint256 mapSlot, address key) p
         vm.startPrank(Constants.userPublicKey);
         uint256 amount = startingBalance / 2;
         SSM.deposit(amount, Constants.userPublicKey);
-        SSM.cooldown(amount);
+        SSM.cooldown(amount*1e18);
         vm.warp(block.timestamp + SSM.cooldownLength() - 100);
         vm.expectRevert();
         SSM.withdraw(amount, Constants.userPublicKey, Constants.userPublicKey);
@@ -175,7 +175,7 @@ function getMappingValue(address targetContract, uint256 mapSlot, address key) p
         vm.startPrank(Constants.userPublicKey);
         uint256 amount = startingBalance / 2;
         SSM.deposit(amount, Constants.userPublicKey);
-        SSM.cooldown(amount-1);
+        SSM.cooldown(amount*1e18-1);
         vm.warp(block.timestamp + SSM.cooldownLength());
         vm.expectRevert();
         SSM.withdraw(amount, Constants.userPublicKey, Constants.userPublicKey);
@@ -185,7 +185,7 @@ function getMappingValue(address targetContract, uint256 mapSlot, address key) p
         vm.startPrank(Constants.userPublicKey);
         uint256 amount = startingBalance / 2;
         SSM.deposit(amount, Constants.userPublicKey);
-        SSM.cooldown(amount);
+        SSM.cooldown(amount*1e18);
         vm.warp(block.timestamp + SSM.cooldownLength() + SSM.withdrawalWindow() + 1);
         vm.expectRevert();
         SSM.withdraw(amount, Constants.userPublicKey, Constants.userPublicKey);
@@ -196,7 +196,7 @@ function getMappingValue(address targetContract, uint256 mapSlot, address key) p
         uint256 amount = startingBalance / 2;
         SSM.deposit(amount, Constants.userPublicKey);
 
-        SSM.cooldown(amount);
+        SSM.cooldown(amount*1e18);
         assertEq(SSM.cooldownTime(Constants.userPublicKey), block.timestamp + SSM.cooldownLength());
         assertEq(SSM.cooldownAmount(Constants.userPublicKey), amount*1e18);
         vm.warp(block.timestamp + SSM.cooldownLength());
@@ -211,7 +211,7 @@ function getMappingValue(address targetContract, uint256 mapSlot, address key) p
         uint256 amount = (startingBalance * 1e18) / 2;
         SSM.mint(amount, Constants.userPublicKey);
 
-        SSM.cooldown(amount/1e18);
+        SSM.cooldown(amount);
         assertEq(SSM.cooldownTime(Constants.userPublicKey), block.timestamp + SSM.cooldownLength());
         assertEq(SSM.cooldownAmount(Constants.userPublicKey), amount);
         vm.warp(block.timestamp + SSM.cooldownLength());


### PR DESCRIPTION
- Mint and Redeem already inherently have slippage checks through their usage of a `shares` param, which itself is always proportional to the amount of `assets` (bpt) being transacted
- Deposit:
       - The deposit method requires a user receive a minimum amount of bpt (`minimumBPT`) for their assets deposited, accounting for slippage.
- Withdraw:
       - The withdraw method requires a user spend a maximum amount of bpt (`maximumBPT`) for the requested assets redeemed, accounting for slippage.
- Removed the `TestException` event
- Added maximum withdrawals on the admin
- Added time limits between admin withdrawals for a given token