### PR TITLE
Remove cooldownTime reset + subtract shares from cooldownAmount

### DIFF
--- a/src/Interfaces/IBalancerMinter.sol
+++ b/src/Interfaces/IBalancerMinter.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity >=0.7.0 <0.9.0;
+
+interface IBalancerMinter {
+    function mint(address gauge) external returns (uint256);
+}

--- a/src/stkSWIV.sol
+++ b/src/stkSWIV.sol
@@ -276,7 +276,7 @@ contract stkSWIV is ERC20 {
     // @returns: the amount of stkSWIV shares withdrawn
     function withdraw(uint256 assets, address receiver, address owner) Unpaused()  public returns (uint256) {
         // Convert assets to shares
-        uint256 shares = previewWithdraw(assets);(assets);
+        uint256 shares = previewWithdraw(assets);
         // Get the cooldown time
         uint256 cTime = cooldownTime[msg.sender];
         // If the sender is not the owner check allowances

--- a/src/stkSWIV.sol
+++ b/src/stkSWIV.sol
@@ -123,8 +123,9 @@ contract stkSWIV is ERC20 {
 
     // Preview the amount of stkSWIV received from zapping and depositing `swivelAmount` of SWIV alongside a proportional amount of ETH
     // @param: swivelAmount - amount of SWIV tokens
+    // @param: ethAmount - amount of ETH
     // @returns: shares the amount of stkSWIV shares received
-    function previewDepositZap(uint256 swivelAmount) public returns (uint256 shares) {
+    function previewDepositZap(uint256 swivelAmount, uint256 ethAmount) public returns (uint256 shares, uint256[2] balancesSpent) {
         // Instantiate balancer request struct using SWIV and ETH alongside the amounts sent
         IAsset[] memory assetData = new IAsset[](2);
         assetData[0] = IAsset(address(SWIV));
@@ -132,7 +133,7 @@ contract stkSWIV is ERC20 {
 
         uint256[] memory amountData = new uint256[](2);
         amountData[0] = swivelAmount;
-        amountData[1] = type(uint256).max;
+        amountData[1] = ethAmount;
 
         IVault.JoinPoolRequest memory requestData = IVault.JoinPoolRequest({
                     assets: assetData,
@@ -143,7 +144,7 @@ contract stkSWIV is ERC20 {
         // Query the pool join to get the bpt out
         (uint256 bptOut, uint256[] memory amountsIn) = balancerQuery.queryJoin(balancerPoolID, msg.sender, address(this), requestData);
 
-        return (convertToShares(bptOut));
+        return (convertToShares(bptOut), [amountsIn[0], amountsIn[1]]);
     }
 
     // Preview of the amount of stkSWIV required to withdraw `assets` of balancerLPT
@@ -181,9 +182,9 @@ contract stkSWIV is ERC20 {
         return (type(uint256).max);
     }
 
-    // Queues `amount` of balancerLPT assets to be withdrawn after the cooldown period
-    // @param: amount - amount of balancerLPT assets to be withdrawn
-    // @returns: the total amount of balancerLPT assets to be withdrawn
+    // Queues `amount` of stkSWIV shares to be withdrawn after the cooldown period
+    // @param: amount - amount of stkSWIV shares to be withdrawn
+    // @returns: the total amount of stkSWIV shares to be withdrawn
     function cooldown(uint256 shares) public returns (uint256) {
         // Require the total amount to be < balanceOf
         if (cooldownAmount[msg.sender] + shares > balanceOf[msg.sender]) {

--- a/src/stkSWIV.sol
+++ b/src/stkSWIV.sol
@@ -244,10 +244,8 @@ contract stkSWIV is ERC20 {
         SafeTransferLib.transfer(balancerLPT, receiver, assets);
         // Burn the shares
         _burn(msg.sender, shares);
-        // Reset the cooldown time
-        cooldownTime[msg.sender] = 0;
         // Reset the cooldown amount
-        cooldownAmount[msg.sender] = 0;
+        cooldownAmount[msg.sender] = cooldownAmount[msg.sender] - shares;
         // Emit withdraw event
         emit Withdraw(msg.sender, receiver, owner, assets, shares);
 
@@ -304,10 +302,8 @@ contract stkSWIV is ERC20 {
         SafeTransferLib.transfer(balancerLPT, receiver, assets);
         // Burn the shares   
         _burn(msg.sender, shares);
-        // Reset the cooldown time
-        cooldownTime[msg.sender] = 0;
         // Reset the cooldown amount
-        cooldownAmount[msg.sender] = 0;
+        cooldownAmount[msg.sender] = cooldownAmount[msg.sender] - shares;
         // Emit withdraw event
         emit Withdraw(msg.sender, receiver, owner, assets, shares);
 
@@ -452,14 +448,12 @@ contract stkSWIV is ERC20 {
         receiver.transfer(address(this).balance);
         // Burn the shares
         _burn(msg.sender, shares);
-        // // Reset the cooldown time
-        cooldownTime[msg.sender] = 0;
         // // Reset the cooldown amount
-        cooldownAmount[msg.sender] = 0;
+        cooldownAmount[msg.sender] = cooldownAmount[msg.sender] - shares;
         // // Emit withdraw event
         emit Withdraw(msg.sender, receiver, owner, bptIn, shares);
 
-        return (assets, shares, [amountsOut[0], amountsOut[1]]);
+        return (bptIn, shares, [amountsOut[0], amountsOut[1]]);
     }
 
     // Transfers `assets` of SWIV tokens from `msg.sender` while receiving `msg.value` of ETH
@@ -592,10 +586,8 @@ contract stkSWIV is ERC20 {
         receiver.transfer(amountsOut[1]);
         // Burn the shares
         _burn(msg.sender, sharesRedeemed);
-        // Reset the cooldown time
-        cooldownTime[msg.sender] = 0;
         // Reset the cooldown amount
-        cooldownAmount[msg.sender] = 0;
+        cooldownAmount[msg.sender] = cooldownAmount[msg.sender] - sharesRedeemed;
         // Emit withdraw event
         emit Withdraw(msg.sender, receiver, owner, bptOut, sharesRedeemed);
 

--- a/src/stkSWIV.sol
+++ b/src/stkSWIV.sol
@@ -632,10 +632,10 @@ contract stkSWIV is ERC20 {
     }
 
     // Method to redeem BAL incentives from a given balancer gauge
-    // @param: gauge - address of the balancer gauge
     // @param: receiver - address of the receiver
+    // @param: gauge - address of the balancer gauge
     // @returns: the amount of BAL withdrawn
-    function adminWithdrawBAL(address gauge, address balancerMinter, address receiver) Authorized(admin) public returns (uint256) {
+    function adminWithdrawBAL(address balancerMinter, address gauge, address receiver) Authorized(admin) public returns (uint256) {
         // Mint BAL accrued on a given gauge
         uint256 amount = IBalancerMinter(balancerMinter).mint(gauge);
         // Transfer the tokens to the receiver


### PR DESCRIPTION
The methods in question are only the redeems + withdraws.

Very straightforward with minor double checking probably good on the zap methods where the actually transacted `shares` may be a slightly different amount than the input `shares` 